### PR TITLE
Add export of JSON summary from a changeset

### DIFF
--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -314,7 +314,7 @@ int GEODIFF_changesCount( const char *changeset )
   }
 }
 
-int GEODIFF_listChanges( const char *changeset, const char *jsonfile )
+static int listChangesJSON( const char *changeset, const char *jsonfile, bool onlySummary )
 {
   try
   {
@@ -339,7 +339,7 @@ int GEODIFF_listChanges( const char *changeset, const char *jsonfile )
       throw GeoDiffException( "Unable to enable sqlite3/gpkg extensions" );
     }
 
-    std::string res = GeoDiffExporter::toJSON( db, buf );
+    std::string res = onlySummary ? GeoDiffExporter::toJSONSummary( buf ) : GeoDiffExporter::toJSON( db, buf );
     flushString( jsonfile, res );
     return GEODIFF_SUCCESS;
   }
@@ -348,4 +348,14 @@ int GEODIFF_listChanges( const char *changeset, const char *jsonfile )
     Logger::instance().error( exc );
     return GEODIFF_ERROR;
   }
+}
+
+int GEODIFF_listChanges( const char *changeset, const char *jsonfile )
+{
+  return listChangesJSON( changeset, jsonfile, false );
+}
+
+int GEODIFF_listChangesSummary( const char *changeset, const char *jsonfile )
+{
+  return listChangesJSON( changeset, jsonfile, true );
 }

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -133,6 +133,15 @@ GEODIFF_EXPORT int GEODIFF_listChanges(
   const char *jsonfile
 );
 
+/**
+ * Export summary of changeset to JSON
+ * \returns GEODIFF_SUCCESS on success
+ */
+GEODIFF_EXPORT int GEODIFF_listChangesSummary(
+  const char *changeset,
+  const char *jsonfile
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/geodiff/src/geodiffexporter.hpp
+++ b/geodiff/src/geodiffexporter.hpp
@@ -19,6 +19,8 @@ namespace GeoDiffExporter
   std::string toString( sqlite3_changeset_iter *pp );
   std::string toJSON( std::shared_ptr<Sqlite3Db> db, Buffer &buf );
   std::string toJSON( std::shared_ptr<Sqlite3Db> db, Sqlite3ChangesetIter &pp );
+
+  std::string toJSONSummary( Buffer &buf );
 }
 
 #endif // GEODIFFEXPORTER_H

--- a/geodiff/src/geodiffinfo.cpp
+++ b/geodiff/src/geodiffinfo.cpp
@@ -17,12 +17,13 @@ void help()
   printf( "[create rebased changeset] geodiffinfo createRebasedChangeset base modified changeset_their changeset\n" );
   printf( "[apply changeset] geodiffinfo applyChangeset base patched changeset\n" );
   printf( "[list changes (JSON) in changeset] geodiffinfo listChanges changeset json\n" );
+  printf( "[list summary of changes (JSON) in changeset] geodiffinfo listChangesSummary changeset json\n" );
 }
 
 int err( const std::string msg )
 {
   help();
-  printf( "ERROR: %s", msg.c_str() );
+  printf( "ERROR: %s\n", msg.c_str() );
   return 1;
 }
 
@@ -63,10 +64,21 @@ int listChanges( int argc, char *argv[] )
 {
   if ( argc < 1 + 2 )
   {
-    return err( "invalid number of arguments to listChangesJSON" );
+    return err( "invalid number of arguments to listChanges" );
   }
 
   int ret = GEODIFF_listChanges( argv[2], argv[3] );
+  return ret;
+}
+
+int listChangesSummary( int argc, char *argv[] )
+{
+  if ( argc < 1 + 2 )
+  {
+    return err( "invalid number of arguments to listChangesSummary" );
+  }
+
+  int ret = GEODIFF_listChangesSummary( argv[2], argv[3] );
   return ret;
 }
 
@@ -97,6 +109,10 @@ int main( int argc, char *argv[] )
     else if ( mode == "listChanges" )
     {
       return listChanges( argc, argv );
+    }
+    else if ( mode == "listChangesSummary" )
+    {
+      return listChangesSummary( argc, argv );
     }
     else
     {


### PR DESCRIPTION
It is useful for testing to be able to get just a short summary of changes (numbers of inserts/updates/deletes for each table).