### PR TITLE
fix #38 create conflict files [API BREAK]

### DIFF
--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -238,16 +238,15 @@ int GEODIFF_createRebasedChangeset( const char *base,
                                     const char *modified,
                                     const char *changeset_their,
                                     const char *changeset,
-                                    const char *conflictfile,
-                                    int *nConflicts )
+                                    const char *conflictfile
+                                  )
 {
-  if ( !conflictfile || !nConflicts )
+  if ( !conflictfile )
   {
     Logger::instance().error( "NULL arguments to GEODIFF_createRebasedChangeset" );
     return GEODIFF_ERROR;
   }
   fileremove( conflictfile );
-  *nConflicts = 0;
 
   try
   {
@@ -274,10 +273,16 @@ int GEODIFF_createRebasedChangeset( const char *base,
     rc = rebase( changeset_their, changeset, changeset_BASE_MODIFIED.path(), conflicts );
 
     // output conflicts
-    *nConflicts = conflicts.size();
-    GeoDiffExporter exporter;
-    std::string res = exporter.toJSON( conflicts );
-    flushString( conflictfile, res );
+    if ( conflicts.empty() )
+    {
+      Logger::instance().debug( "No conflicts present" );
+    }
+    else
+    {
+      GeoDiffExporter exporter;
+      std::string res = exporter.toJSON( conflicts );
+      flushString( conflictfile, res );
+    }
 
     return rc;
   }
@@ -434,10 +439,9 @@ int GEODIFF_invertChangeset( const char *changeset, const char *changeset_inv )
 int GEODIFF_rebase( const char *base,
                     const char *modified_their,
                     const char *modified,
-                    const char *conflictfile,
-                    int *nConflicts )
+                    const char *conflictfile )
 {
-  if ( !base || !modified || !modified || !conflictfile || !nConflicts )
+  if ( !base || !modified || !modified || !conflictfile )
   {
     Logger::instance().error( "NULL arguments to GEODIFF_rebase" );
     return GEODIFF_ERROR;
@@ -448,8 +452,6 @@ int GEODIFF_rebase( const char *base,
     Logger::instance().error( "Missing input files in GEODIFF_rebase" );
     return GEODIFF_ERROR;
   }
-
-  *nConflicts = 0;
 
   try
   {
@@ -491,7 +493,7 @@ int GEODIFF_rebase( const char *base,
 
     // 3A) Create all changesets
     TmpFile theirs2final( root + "_theirs2final.bin" );
-    if ( GEODIFF_createRebasedChangeset( base, modified, base2theirs.c_path(), theirs2final.c_path(), conflictfile, nConflicts ) != GEODIFF_SUCCESS )
+    if ( GEODIFF_createRebasedChangeset( base, modified, base2theirs.c_path(), theirs2final.c_path(), conflictfile ) != GEODIFF_SUCCESS )
     {
       Logger::instance().error( "Unable to perform GEODIFF_createChangeset theirs2final" );
       return GEODIFF_ERROR;

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -230,8 +230,21 @@ int GEODIFF_applyChangeset( const char *base, const char *changeset )
   }
 }
 
-int GEODIFF_createRebasedChangeset( const char *base, const char *modified, const char *changeset_their, const char *changeset )
+int GEODIFF_createRebasedChangeset( const char *base,
+                                    const char *modified,
+                                    const char *changeset_their,
+                                    const char *changeset,
+                                    const char *conflictfile,
+                                    int *nConflicts )
 {
+  if ( !conflictfile || !nConflicts )
+  {
+    Logger::instance().error( "NULL arguments to GEODIFF_createRebasedChangeset" );
+    return GEODIFF_ERROR;
+  }
+  fileremove( conflictfile );
+  *nConflicts = 0;
+
   try
   {
     // get all triggers sql commands
@@ -253,7 +266,16 @@ int GEODIFF_createRebasedChangeset( const char *base, const char *modified, cons
     if ( rc != GEODIFF_SUCCESS )
       return rc;
 
-    return rebase( changeset_their, changeset, changeset_BASE_MODIFIED.path() );
+    std::vector<ConflictFeature> conflicts;
+    rc = rebase( changeset_their, changeset, changeset_BASE_MODIFIED.path(), conflicts );
+
+    // output conflicts
+    *nConflicts = conflicts.size();
+    GeoDiffExporter exporter;
+    std::string res = exporter.toJSON( conflicts );
+    flushString( conflictfile, res );
+
+    return rc;
   }
   catch ( GeoDiffException exc )
   {
@@ -333,21 +355,8 @@ static int listChangesJSON( const char *changeset, const char *jsonfile, bool on
       return 0;
     }
 
-    std::shared_ptr<Sqlite3Db> db = std::make_shared<Sqlite3Db>();
-    db->open( ":memory:" );
-    std::string cmd = "CREATE TABLE gpkg_contents (table_name TEXT NOT NULL PRIMARY KEY,data_type TEXT NOT NULL,identifier TEXT UNIQUE,description TEXT DEFAULT '',last_change DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),min_x DOUBLE, min_y DOUBLE,max_x DOUBLE, max_y DOUBLE,srs_id INTEGER)";
-    Sqlite3Stmt statament;
-    statament.prepare( db, "%s", cmd.c_str() );
-    sqlite3_step( statament.get() );
-    statament.close();
-
-    bool success = register_gpkg_extensions( db );
-    if ( !success )
-    {
-      throw GeoDiffException( "Unable to enable sqlite3/gpkg extensions" );
-    }
-
-    std::string res = onlySummary ? GeoDiffExporter::toJSONSummary( buf ) : GeoDiffExporter::toJSON( db, buf );
+    GeoDiffExporter exporter;
+    std::string res = onlySummary ? exporter.toJSONSummary( buf ) : exporter.toJSON( buf );
     flushString( jsonfile, res );
     return GEODIFF_SUCCESS;
   }
@@ -418,9 +427,13 @@ int GEODIFF_invertChangeset( const char *changeset, const char *changeset_inv )
   }
 }
 
-int GEODIFF_rebase( const char *base, const char *modified_their, const char *modified )
+int GEODIFF_rebase( const char *base,
+                    const char *modified_their,
+                    const char *modified,
+                    const char *conflictfile,
+                    int *nConflicts )
 {
-  if ( !base || !modified || !modified )
+  if ( !base || !modified || !modified || !conflictfile || !nConflicts )
   {
     Logger::instance().error( "NULL arguments to GEODIFF_rebase" );
     return GEODIFF_ERROR;
@@ -431,6 +444,8 @@ int GEODIFF_rebase( const char *base, const char *modified_their, const char *mo
     Logger::instance().error( "Missing input files in GEODIFF_rebase" );
     return GEODIFF_ERROR;
   }
+
+  *nConflicts = 0;
 
   try
   {
@@ -472,7 +487,7 @@ int GEODIFF_rebase( const char *base, const char *modified_their, const char *mo
 
     // 3A) Create all changesets
     TmpFile theirs2final( root + "_theirs2final.bin" );
-    if ( GEODIFF_createRebasedChangeset( base, modified, base2theirs.c_path(), theirs2final.c_path() ) != GEODIFF_SUCCESS )
+    if ( GEODIFF_createRebasedChangeset( base, modified, base2theirs.c_path(), theirs2final.c_path(), conflictfile, nConflicts ) != GEODIFF_SUCCESS )
     {
       Logger::instance().error( "Unable to perform GEODIFF_createChangeset theirs2final" );
       return GEODIFF_ERROR;

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -131,13 +131,18 @@ GEODIFF_EXPORT int GEODIFF_invertChangeset( const char *changeset, const char *c
  * \param modified [input] MODIFIED sqlite3/geopackage file
  * \param changeset_their [input] changeset between BASE -> MODIFIED_THEIR
  * \param changeset [output] changeset between MODIFIED_THEIR -> MODIFIED_THEIR_PLUS_MINE
+ * \param conflictfile [output] json file containing all the automaticly resolved conflicts
+ * \param nConflicts [output] number of conflicts stored in json file
  * \returns GEODIFF_SUCCESS on success
  */
 GEODIFF_EXPORT int GEODIFF_createRebasedChangeset(
   const char *base,
   const char *modified,
   const char *changeset_their,
-  const char *changeset );
+  const char *changeset,
+  const char *conflictfile,
+  int *nConflicts
+);
 
 
 /**
@@ -158,17 +163,28 @@ GEODIFF_EXPORT int GEODIFF_createRebasedChangeset(
  * \param base [input] BASE sqlite3/geopackage file
  * \param modified_their [input] MODIFIED sqlite3/geopackage file
  * \param modified [input/output] local copy of the changes to be rebased
+ * \param conflictfile [output] json file containing all the automaticly resolved conflicts
+ * \param nConflicts [output] number of conflicts stored in json file
  * \returns GEODIFF_SUCCESS on success
  */
 GEODIFF_EXPORT int GEODIFF_rebase(
   const char *base,
   const char *modified_their,
-  const char *modified
+  const char *modified,
+  const char *conflictfile,
+  int *nConflicts
 );
 
 
 /**
  * Applies changeset file (binary) to BASE
+ *
+ * When changeset is correctly formed (for example after successfull rebase),
+ * the applyChanges should not raise any conflict. The GEODIFF_CONFICTS error
+ * suggests that the base or changeset are not match each other (e.g. changeset
+ * created from different base file) or can suggest a internal bug in rebase routine.
+ * With WARN logging level client should be able to see the place of conflicts.
+ *
  * \param base [input/output] BASE sqlite3/geopackage file
  * \param changeset [input] changeset to apply to BASE
  * \returns GEODIFF_SUCCESS on success

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -179,7 +179,7 @@ GEODIFF_EXPORT int GEODIFF_rebase(
 /**
  * Applies changeset file (binary) to BASE
  *
- * When changeset is correctly formed (for example after successfull rebase),
+ * When changeset is correctly formed (for example after successful rebase),
  * the applyChanges should not raise any conflict. The GEODIFF_CONFICTS error
  * suggests that the base or changeset are not match each other (e.g. changeset
  * created from different base file) or can suggest a internal bug in rebase routine.

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -186,7 +186,7 @@ GEODIFF_EXPORT int GEODIFF_rebase(
  *
  * When changeset is correctly formed (for example after successful rebase),
  * the applyChanges should not raise any conflict. The GEODIFF_CONFLICTS error
- * suggests that the base or changeset are not match each other (e.g. changeset
+ * suggests that the base or changeset are not matching each other (e.g. changeset
  * created from different base file) or can suggest an internal bug in rebase routine.
  * With WARN logging level client should be able to see the place of conflicts.
  *

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -140,8 +140,7 @@ GEODIFF_EXPORT int GEODIFF_invertChangeset( const char *changeset, const char *c
  * \param modified [input] MODIFIED sqlite3/geopackage file
  * \param changeset_their [input] changeset between BASE -> MODIFIED_THEIR
  * \param changeset [output] changeset between MODIFIED_THEIR -> MODIFIED_THEIR_PLUS_MINE
- * \param conflictfile [output] json file containing all the automaticly resolved conflicts
- * \param nConflicts [output] number of conflicts stored in json file
+ * \param conflictfile [output] json file containing all the automaticly resolved conflicts. If there are no conflicts, file is not created
  * \returns GEODIFF_SUCCESS on success
  */
 GEODIFF_EXPORT int GEODIFF_createRebasedChangeset(
@@ -149,8 +148,7 @@ GEODIFF_EXPORT int GEODIFF_createRebasedChangeset(
   const char *modified,
   const char *changeset_their,
   const char *changeset,
-  const char *conflictfile,
-  int *nConflicts
+  const char *conflictfile
 );
 
 
@@ -172,16 +170,14 @@ GEODIFF_EXPORT int GEODIFF_createRebasedChangeset(
  * \param base [input] BASE sqlite3/geopackage file
  * \param modified_their [input] MODIFIED sqlite3/geopackage file
  * \param modified [input/output] local copy of the changes to be rebased
- * \param conflictfile [output] json file containing all the automaticly resolved conflicts
- * \param nConflicts [output] number of conflicts stored in json file
+ * \param conflictfile [output] json file containing all the automaticly resolved conflicts. If there are no conflicts, file is not created
  * \returns GEODIFF_SUCCESS on success
  */
 GEODIFF_EXPORT int GEODIFF_rebase(
   const char *base,
   const char *modified_their,
   const char *modified,
-  const char *conflictfile,
-  int *nConflicts
+  const char *conflictfile
 );
 
 

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -182,7 +182,7 @@ GEODIFF_EXPORT int GEODIFF_rebase(
  * When changeset is correctly formed (for example after successful rebase),
  * the applyChanges should not raise any conflict. The GEODIFF_CONFLICTS error
  * suggests that the base or changeset are not match each other (e.g. changeset
- * created from different base file) or can suggest a internal bug in rebase routine.
+ * created from different base file) or can suggest an internal bug in rebase routine.
  * With WARN logging level client should be able to see the place of conflicts.
  *
  * \param base [input/output] BASE sqlite3/geopackage file

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -180,7 +180,7 @@ GEODIFF_EXPORT int GEODIFF_rebase(
  * Applies changeset file (binary) to BASE
  *
  * When changeset is correctly formed (for example after successful rebase),
- * the applyChanges should not raise any conflict. The GEODIFF_CONFICTS error
+ * the applyChanges should not raise any conflict. The GEODIFF_CONFLICTS error
  * suggests that the base or changeset are not match each other (e.g. changeset
  * created from different base file) or can suggest a internal bug in rebase routine.
  * With WARN logging level client should be able to see the place of conflicts.

--- a/geodiff/src/geodiffexporter.cpp
+++ b/geodiff/src/geodiffexporter.cpp
@@ -310,6 +310,7 @@ std::string GeoDiffExporter::toJSON( const ConflictFeature &conflict ) const
   std::string res = "      {\n";
   res += "        \"table\": \"" + std::string( conflict.tableName() ) + "\",\n";
   res += "        \"type\": \"" + status + "\",\n";
+  res += "        \"fid\": \"" + std::to_string( conflict.pk() ) + "\",\n";
   res += "        \"changes\": [";
   bool first = true;
 

--- a/geodiff/src/geodiffexporter.cpp
+++ b/geodiff/src/geodiffexporter.cpp
@@ -21,6 +21,11 @@
 #include <iostream>
 #include <sstream>
 
+GeoDiffExporter::GeoDiffExporter()
+{
+  mDb = blankGeopackageDb();
+}
+
 std::string GeoDiffExporter::toString( sqlite3_changeset_iter *pp )
 {
   std::ostringstream ret;
@@ -72,15 +77,15 @@ std::string GeoDiffExporter::toString( sqlite3_changeset_iter *pp )
   return ret.str();
 }
 
-void _addValue( std::shared_ptr<Sqlite3Db> db, std::string &stream,
-                sqlite3_value *ppValue, const std::string &type )
+void GeoDiffExporter::addValue( std::string &stream,
+                                sqlite3_value *ppValue, const std::string &type ) const
 {
   std::string val;
   if ( ppValue )
   {
     if ( sqlite3_value_type( ppValue ) == SQLITE_BLOB )
     {
-      val = convertGeometryToWKT( db, ppValue );
+      val = convertGeometryToWKT( mDb, ppValue );
       if ( val.empty() )
         val = Sqlite3Value::toString( ppValue );
     }
@@ -101,7 +106,16 @@ void _addValue( std::shared_ptr<Sqlite3Db> db, std::string &stream,
   }
 }
 
-std::string GeoDiffExporter::toJSON( std::shared_ptr<Sqlite3Db> db, Sqlite3ChangesetIter &pp )
+void GeoDiffExporter::addValue( std::string &stream,
+                                std::shared_ptr<Sqlite3Value> value, const std::string &type ) const
+{
+  if ( value )
+    return addValue( stream, value->value(), type );
+  else
+    return addValue( stream, nullptr, type );
+}
+
+std::string GeoDiffExporter::toJSON( Sqlite3ChangesetIter &pp ) const
 {
   if ( !pp.get() )
     return std::string();
@@ -173,9 +187,9 @@ std::string GeoDiffExporter::toJSON( std::shared_ptr<Sqlite3Db> db, Sqlite3Chang
       }
       res += "              \"column\": " + std::to_string( i ) + ",\n";
 
-      _addValue( db, res, ppValueOld, "old" );
+      addValue( res, ppValueOld, "old" );
       res += ",\n";
-      _addValue( db, res, ppValueNew, "new" );
+      addValue( res, ppValueNew, "new" );
       res += "\n";
       res += "          }";
     }
@@ -187,7 +201,7 @@ std::string GeoDiffExporter::toJSON( std::shared_ptr<Sqlite3Db> db, Sqlite3Chang
   return res;
 }
 
-std::string GeoDiffExporter::toJSON( std::shared_ptr<Sqlite3Db> db, Buffer &buf )
+std::string GeoDiffExporter::toJSON( Buffer &buf ) const
 {
   std::string res = "{\n   \"geodiff\": [";
 
@@ -196,7 +210,7 @@ std::string GeoDiffExporter::toJSON( std::shared_ptr<Sqlite3Db> db, Buffer &buf 
   bool first = true;
   while ( SQLITE_ROW == sqlite3changeset_next( pp.get() ) )
   {
-    std::string msg = GeoDiffExporter::toJSON( db, pp );
+    std::string msg = GeoDiffExporter::toJSON( pp );
     if ( msg.empty() )
       continue;
 
@@ -225,7 +239,7 @@ struct TableSummary
   int deletes;
 };
 
-std::string GeoDiffExporter::toJSONSummary( Buffer &buf )
+std::string GeoDiffExporter::toJSONSummary( Buffer &buf ) const
 {
   std::map< std::string, TableSummary > summary;
 
@@ -284,6 +298,71 @@ std::string GeoDiffExporter::toJSONSummary( Buffer &buf )
     }
 
   }
+  res += "\n   ]\n";
+  res += "}";
+  return res;
+}
+
+std::string GeoDiffExporter::toJSON( const ConflictFeature &conflict ) const
+{
+  std::string status = "conflict";
+
+  std::string res = "      {\n";
+  res += "        \"table\": \"" + std::string( conflict.tableName() ) + "\",\n";
+  res += "        \"type\": \"" + status + "\",\n";
+  res += "        \"changes\": [";
+  bool first = true;
+
+  const std::vector<ConflictItem> items = conflict.items();
+  for ( const ConflictItem &item : items )
+  {
+    if ( first )
+    {
+      first = false;
+      res += "\n          {\n";
+    }
+    else
+    {
+      res += ",\n          {\n";
+    }
+    res += "              \"column\": " + std::to_string( item.column() ) + ",\n";
+    addValue( res, item.base(), "base" );
+    res += ",\n";
+    addValue( res, item.theirs(), "old" );
+    res += ",\n";
+    addValue( res, item.ours(), "new" );
+    res += "\n";
+    res += "          }";
+
+  }
+  // close brackets
+  res += "\n        ]\n"; // end properties
+  res += "      }"; // end feature
+  return res;
+}
+
+std::string GeoDiffExporter::toJSON( const std::vector<ConflictFeature> &conflicts ) const
+{
+  std::string res = "{\n   \"geodiff\": [";
+
+  bool first = true;
+  for ( const ConflictFeature &item : conflicts )
+  {
+    std::string msg = GeoDiffExporter::toJSON( item );
+    if ( msg.empty() )
+      continue;
+
+    if ( first )
+    {
+      res += "\n" + msg;
+      first = false;
+    }
+    else
+    {
+      res += ",\n" + msg;
+    }
+  }
+
   res += "\n   ]\n";
   res += "}";
   return res;

--- a/geodiff/src/geodiffexporter.hpp
+++ b/geodiff/src/geodiffexporter.hpp
@@ -14,13 +14,27 @@
 #include "sqlite3.h"
 #include "geodiffutils.hpp"
 
-namespace GeoDiffExporter
+class GeoDiffExporter
 {
-  std::string toString( sqlite3_changeset_iter *pp );
-  std::string toJSON( std::shared_ptr<Sqlite3Db> db, Buffer &buf );
-  std::string toJSON( std::shared_ptr<Sqlite3Db> db, Sqlite3ChangesetIter &pp );
+  public:
+    GeoDiffExporter();
 
-  std::string toJSONSummary( Buffer &buf );
-}
+    static std::string toString( sqlite3_changeset_iter *pp );
+
+    std::string toJSON( Buffer &buf ) const;
+    std::string toJSON( Sqlite3ChangesetIter &pp ) const;
+    std::string toJSON( const ConflictFeature &conflict ) const;
+    std::string toJSON( const std::vector<ConflictFeature> &conflicts ) const;
+    std::string toJSONSummary( Buffer &buf ) const;
+
+  private:
+    void addValue( std::string &stream,
+                   std::shared_ptr<Sqlite3Value> value, const std::string &type ) const;
+
+    void addValue( std::string &stream,
+                   sqlite3_value *ppValue, const std::string &type ) const;
+
+    std::shared_ptr<Sqlite3Db> mDb; // to be able to run ST_* functions
+};
 
 #endif // GEODIFFEXPORTER_H

--- a/geodiff/src/geodiffinfo.cpp
+++ b/geodiff/src/geodiffinfo.cpp
@@ -18,7 +18,7 @@ void help()
   printf( "by default you get only errors printed to stdout\n\n" );
   printf( "[version info] geodiffinfo version\n" );
   printf( "[create changeset] geodiffinfo createChangeset base modified changeset\n" );
-  printf( "[create rebased changeset] geodiffinfo createRebasedChangeset base modified changeset_their changeset\n" );
+  printf( "[create rebased changeset] geodiffinfo createRebasedChangeset base modified changeset_their changeset conflict\n" );
   printf( "[apply changeset] geodiffinfo applyChangeset base changeset\n" );
   printf( "[list changes (JSON) in changeset] geodiffinfo listChanges changeset json\n" );
   printf( "[list summary of changes (JSON) in changeset] geodiffinfo listChangesSummary changeset json\n" );
@@ -44,12 +44,13 @@ int createChangeset( int argc, char *argv[] )
 
 int createRebasedChangeset( int argc, char *argv[] )
 {
-  if ( argc < 1 + 5 )
+  if ( argc < 1 + 6 )
   {
     return err( "invalid number of arguments to createRebasedChangeset" );
   }
 
-  int ret = GEODIFF_createRebasedChangeset( argv[2], argv[3], argv[4], argv[5] );
+  int nConflicts;
+  int ret = GEODIFF_createRebasedChangeset( argv[2], argv[3], argv[4], argv[5], argv[6], &nConflicts );
   return ret;
 }
 

--- a/geodiff/src/geodiffinfo.cpp
+++ b/geodiff/src/geodiffinfo.cpp
@@ -49,8 +49,7 @@ int createRebasedChangeset( int argc, char *argv[] )
     return err( "invalid number of arguments to createRebasedChangeset" );
   }
 
-  int nConflicts;
-  int ret = GEODIFF_createRebasedChangeset( argv[2], argv[3], argv[4], argv[5], argv[6], &nConflicts );
+  int ret = GEODIFF_createRebasedChangeset( argv[2], argv[3], argv[4], argv[5], argv[6] );
   return ret;
 }
 

--- a/geodiff/src/geodiffrebase.hpp
+++ b/geodiff/src/geodiffrebase.hpp
@@ -7,11 +7,14 @@
 #define GEODIFFREBASE_H
 
 #include <string>
+#include <vector>
+#include "geodiffutils.hpp"
 
 int rebase(
   const std::string &changeset_BASE_THEIRS, //in
   const std::string &changeset_THEIRS_MODIFIED, // out
-  const std::string &changeset_BASE_MODIFIED //in
+  const std::string &changeset_BASE_MODIFIED, //in
+  std::vector<ConflictFeature> &conflicts// out
 );
 
 // true on error

--- a/geodiff/src/geodiffutils.hpp
+++ b/geodiff/src/geodiffutils.hpp
@@ -39,6 +39,10 @@ class Sqlite3Db
     sqlite3 *mDb = nullptr;
 };
 
+//! Create black simple geopackage database
+//! to be able to run ST_* functions
+std::shared_ptr<Sqlite3Db> blankGeopackageDb();
+
 class Sqlite3Session
 {
   public:
@@ -267,6 +271,43 @@ class TmpFile
     const char *c_path() const;
   private:
     std::string mPath;
+};
+
+class ConflictItem
+{
+  public:
+    ConflictItem(
+      int column,
+      std::shared_ptr<Sqlite3Value> base,
+      std::shared_ptr<Sqlite3Value> theirs,
+      std::shared_ptr<Sqlite3Value> ours );
+
+    std::shared_ptr<Sqlite3Value> base() const;
+    std::shared_ptr<Sqlite3Value> theirs() const;
+    std::shared_ptr<Sqlite3Value> ours() const;
+    int column() const;
+
+  private:
+    int mColumn;
+    std::shared_ptr<Sqlite3Value> mBase;
+    std::shared_ptr<Sqlite3Value> mTheirs;
+    std::shared_ptr<Sqlite3Value> mOurs;
+};
+
+class ConflictFeature
+{
+  public:
+    ConflictFeature( int pk,
+                     const std::string &tableName );
+    bool isValid() const;
+    void addItem( const ConflictItem &item );
+    std::string tableName() const;
+    int pk() const;
+    std::vector<ConflictItem> items() const;
+  private:
+    int mPk;
+    std::string mTableName;
+    std::vector<ConflictItem> mItems;
 };
 
 

--- a/geodiff/tests/geodiff_testutils.cpp
+++ b/geodiff/tests/geodiff_testutils.cpp
@@ -3,10 +3,12 @@
  Copyright (C) 2019 Peter Petrik
 */
 
-#define xstr(a) str(a)
-#define str(a) #a
+//#define xstr(a) str(a)
+//#define str(a) #a
 
 #include "geodiff_testutils.hpp"
+#include <string>
+#include <sstream>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -165,4 +167,33 @@ void printJSON( const std::string &changeset, const std::string &json, const std
   printFileToStdout( "JSON Full", json );
 }
 
+int fileContains( const std::string &filepath, const std::string key )
+{
+  std::ifstream f( filepath );
+  if ( f.is_open() )
+  {
+    std::ostringstream datastream;
+    datastream << f.rdbuf() << '\n';
+    std::string strdata( datastream.str() );
+    int occurences = 0;
+    for ( size_t found( -1 ); ( found = strdata.find( key, found + 1 ) ) != std::string::npos; ++occurences );
+    return occurences;
+  }
+  else
+  {
+    // file does not exist or is not readable
+    return 0;
+  }
+}
+
+bool containsConflict( const std::string &conflictFile, const std::string key )
+{
+  return fileContains( conflictFile, key ) > 0;
+}
+
+
+int countConflicts( const std::string &conflictFile )
+{
+  return fileContains( conflictFile, "fid" );
+}
 

--- a/geodiff/tests/geodiff_testutils.cpp
+++ b/geodiff/tests/geodiff_testutils.cpp
@@ -145,20 +145,23 @@ void makedir( const std::string &dir )
 #endif
 }
 
+void printFileToStdout( const std::string &caption, const std::string &filepath )
+{
+  std::cout << std::endl << caption << " (" << filepath << ")" << std::endl;
+  std::ifstream f( filepath );
+  if ( f.is_open() )
+    std::cout << f.rdbuf();
+}
+
 void printJSON( const std::string &changeset, const std::string &json, const std::string &json_summary )
 {
   // printout JSON summary
-  std::cout << "JSON Summary " << std::endl;
   GEODIFF_listChangesSummary( changeset.c_str(), json_summary.c_str() );
-  std::ifstream f2( json_summary );
-  if ( f2.is_open() )
-    std::cout << f2.rdbuf();
+  printFileToStdout( "JSON Summary", json_summary );
 
   // printout JSON
-  std::cout << std::endl << "JSON Full " << std::endl;
   GEODIFF_listChanges( changeset.c_str(), json.c_str() );
-  std::ifstream f( json );
-  if ( f.is_open() )
-    std::cout << f.rdbuf();
-
+  printFileToStdout( "JSON Full", json );
 }
+
+

--- a/geodiff/tests/geodiff_testutils.hpp
+++ b/geodiff/tests/geodiff_testutils.hpp
@@ -25,6 +25,7 @@ std::string test_file( std::string basename );
 std::string tmp_file( std::string basename );
 
 void printJSON( const std::string &changeset, const std::string &json, const std::string &json_summary );
+void printFileToStdout( const std::string &caption, const std::string &filepath );
 
 /**
  * \param ignore_timestamp_change ignore last_change in table gpkg_contents

--- a/geodiff/tests/geodiff_testutils.hpp
+++ b/geodiff/tests/geodiff_testutils.hpp
@@ -24,8 +24,10 @@ void finalize_test();
 std::string test_file( std::string basename );
 std::string tmp_file( std::string basename );
 
+int fileContains( const std::string &filepath, const std::string key );
 void printJSON( const std::string &changeset, const std::string &json, const std::string &json_summary );
 void printFileToStdout( const std::string &caption, const std::string &filepath );
+int countConflicts( const std::string &conflictFile );
 
 /**
  * \param ignore_timestamp_change ignore last_change in table gpkg_contents

--- a/geodiff/tests/test_concurrent_commits.cpp
+++ b/geodiff/tests/test_concurrent_commits.cpp
@@ -52,8 +52,7 @@ bool _test(
   }
 
   // create changeset A to B
-  int nConflicts = 0;
-  if ( GEODIFF_createRebasedChangeset( base.c_str(), modifiedB.c_str(), changesetbaseA.c_str(), changesetAB.c_str(), conflictAB.c_str(), &nConflicts ) != GEODIFF_SUCCESS )
+  if ( GEODIFF_createRebasedChangeset( base.c_str(), modifiedB.c_str(), changesetbaseA.c_str(), changesetAB.c_str(), conflictAB.c_str() ) != GEODIFF_SUCCESS )
   {
     std::cout << "err GEODIFF_createRebasedChangeset AB" << std::endl;
     return false;
@@ -66,6 +65,7 @@ bool _test(
     return false;
   }
 
+  int nConflicts = countConflicts( conflictAB );
   if ( nConflicts != 0 )
   {
     printFileToStdout( "Conflicts", conflictAB );
@@ -112,13 +112,13 @@ bool _test(
 
   // now check that we get same result in case of direct rebase
   filecopy( patchedAB_2, modifiedB );
-  nConflicts = 0;
-  if ( GEODIFF_rebase( base.c_str(), modifiedA.c_str(), patchedAB_2.c_str(), conflict2.c_str(), &nConflicts ) != GEODIFF_SUCCESS )
+  if ( GEODIFF_rebase( base.c_str(), modifiedA.c_str(), patchedAB_2.c_str(), conflict2.c_str() ) != GEODIFF_SUCCESS )
   {
     std::cout << "err GEODIFF_rebase A" << std::endl;
     return false;
   }
 
+  nConflicts = countConflicts( conflict2 );
   if ( nConflicts != expected_conflicts )
   {
     std::cout << "err GEODIFF_rebase AB conflict: " << nConflicts << " expected: " << expected_conflicts << std::endl;

--- a/geodiff/tests/test_single_commit.cpp
+++ b/geodiff/tests/test_single_commit.cpp
@@ -24,6 +24,7 @@ bool _test(
   std::string changeset_inv = pathjoin( tmpdir(), testname, "changeset_inv.bin" );
   std::string patched = pathjoin( tmpdir(), testname, "patched.gpkg" );
   std::string patched2 = pathjoin( tmpdir(), testname, "patched2.gpkg" );
+  std::string conflict = pathjoin( tmpdir(), testname, "conflict.json" );
   std::string json = pathjoin( tmpdir(), testname, testname + ".json" );
   std::string json_summary = pathjoin( tmpdir(), testname, testname + "_summary.json" );
 
@@ -77,11 +78,19 @@ bool _test(
 
   // check that direct rebase works
   filecopy( patched2, modified );
-  if ( GEODIFF_rebase( base.c_str(), base.c_str(), patched2.c_str() ) != GEODIFF_SUCCESS )
+  int nConflicts;
+  if ( GEODIFF_rebase( base.c_str(), base.c_str(), patched2.c_str(), conflict.c_str(), &nConflicts ) != GEODIFF_SUCCESS )
   {
     std::cout << "err GEODIFF_rebase inversed" << std::endl;
     return false;
   }
+
+  if ( nConflicts != 0 )
+  {
+    std::cout << "conflicts found" << std::endl;
+    return false;
+  }
+
   if ( !equals( patched2, modified, ignore_timestamp_change ) )
   {
     std::cout << "err equals" << std::endl;

--- a/geodiff/tests/test_single_commit.cpp
+++ b/geodiff/tests/test_single_commit.cpp
@@ -78,13 +78,13 @@ bool _test(
 
   // check that direct rebase works
   filecopy( patched2, modified );
-  int nConflicts;
-  if ( GEODIFF_rebase( base.c_str(), base.c_str(), patched2.c_str(), conflict.c_str(), &nConflicts ) != GEODIFF_SUCCESS )
+  if ( GEODIFF_rebase( base.c_str(), base.c_str(), patched2.c_str(), conflict.c_str() ) != GEODIFF_SUCCESS )
   {
     std::cout << "err GEODIFF_rebase inversed" << std::endl;
     return false;
   }
 
+  int nConflicts = countConflicts( conflict );
   if ( nConflicts != 0 )
   {
     std::cout << "conflicts found" << std::endl;

--- a/pygeodiff/geodifflib.py
+++ b/pygeodiff/geodifflib.py
@@ -124,9 +124,9 @@ class GeoDiffLib:
         res = func(b_string1, b_string2)
         _parse_return_code(res, "invert_changeset")
 
-    def create_rebased_changeset(self, base, modified, changeset_their, changeset):
+    def create_rebased_changeset(self, base, modified, changeset_their, changeset, conflict):
         func = self.lib.GEODIFF_createRebasedChangeset
-        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
         func.restype = ctypes.c_int
 
         # create byte objects from the strings
@@ -134,22 +134,27 @@ class GeoDiffLib:
         b_string2 = modified.encode('utf-8')
         b_string3 = changeset_their.encode('utf-8')
         b_string4 = changeset.encode('utf-8')
+        b_string5 = conflict.encode('utf-8')
+        n_conflicts = ctypes.c_int()
 
-        res = func(b_string1, b_string2, b_string3, b_string4)
+        res = func(b_string1, b_string2, b_string3, b_string4, b_string5, ctypes.byref(n_conflicts))
         _parse_return_code(res, "createRebasedChangeset")
+        return n_conflicts.value
 
-    def rebase(self, base, modified_their, modified):
+    def rebase(self, base, modified_their, modified, conflict):
         func = self.lib.GEODIFF_rebase
-        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
         func.restype = ctypes.c_int
 
         # create byte objects from the strings
         b_string1 = base.encode('utf-8')
         b_string2 = modified_their.encode('utf-8')
         b_string3 = modified.encode('utf-8')
-
-        res = func(b_string1, b_string2, b_string3)
+        b_string4 = conflict.encode('utf-8')
+        n_conflicts = ctypes.c_int()
+        res = func(b_string1, b_string2, b_string3, b_string4, ctypes.byref(n_conflicts))
         _parse_return_code(res, "rebase")
+        return n_conflicts.value
 
     def apply_changeset(self, base, changeset):
         func = self.lib.GEODIFF_applyChangeset

--- a/pygeodiff/geodifflib.py
+++ b/pygeodiff/geodifflib.py
@@ -131,7 +131,7 @@ class GeoDiffLib:
 
     def create_rebased_changeset(self, base, modified, changeset_their, changeset, conflict):
         func = self.lib.GEODIFF_createRebasedChangeset
-        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
         func.restype = ctypes.c_int
 
         # create byte objects from the strings
@@ -140,15 +140,13 @@ class GeoDiffLib:
         b_string3 = changeset_their.encode('utf-8')
         b_string4 = changeset.encode('utf-8')
         b_string5 = conflict.encode('utf-8')
-        n_conflicts = ctypes.c_int()
 
-        res = func(b_string1, b_string2, b_string3, b_string4, b_string5, ctypes.byref(n_conflicts))
+        res = func(b_string1, b_string2, b_string3, b_string4, b_string5)
         _parse_return_code(res, "createRebasedChangeset")
-        return n_conflicts.value
 
     def rebase(self, base, modified_their, modified, conflict):
         func = self.lib.GEODIFF_rebase
-        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+        func.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
         func.restype = ctypes.c_int
 
         # create byte objects from the strings
@@ -156,10 +154,8 @@ class GeoDiffLib:
         b_string2 = modified_their.encode('utf-8')
         b_string3 = modified.encode('utf-8')
         b_string4 = conflict.encode('utf-8')
-        n_conflicts = ctypes.c_int()
-        res = func(b_string1, b_string2, b_string3, b_string4, ctypes.byref(n_conflicts))
+        res = func(b_string1, b_string2, b_string3, b_string4)
         _parse_return_code(res, "rebase")
-        return n_conflicts.value
 
     def apply_changeset(self, base, changeset):
         func = self.lib.GEODIFF_applyChangeset

--- a/pygeodiff/main.py
+++ b/pygeodiff/main.py
@@ -98,8 +98,7 @@ class GeoDiff:
              \param base [input] BASE sqlite3/geopackage file
              \param modified_their [input] MODIFIED sqlite3/geopackage file
              \param modified [input] local copy of the changes to be rebased
-             \param conflict [output] file where the automatically resolved conflicts are stored
-             \returns number of conflicts
+             \param conflict [output] file where the automatically resolved conflicts are stored. If there are no conflicts, file is not created
 
              raises SqliteDiffError on error
         """
@@ -120,8 +119,7 @@ class GeoDiff:
              \param modified [input] MODIFIED sqlite3/geopackage file
              \param changeset_their [input] changeset between BASE -> MODIFIED_THEIR
              \param changeset [output] changeset between MODIFIED_THEIR -> MODIFIED_THEIR_PLUS_MINE
-             \param conflict [output] file where the automatically resolved conflicts are stored
-             \returns number of conflicts
+             \param conflict [output] file where the automatically resolved conflicts are stored. If there are no conflicts, file is not created
 
              raises SqliteDiffError on error
         """

--- a/pygeodiff/main.py
+++ b/pygeodiff/main.py
@@ -65,35 +65,59 @@ class GeoDiff:
         return self.clib.invert_changeset(changeset, changeset_inv)
 
     """ 
+        Rebases local modified version from base to modified_their version
+  
+               --- > MODIFIED_THEIR
+        BASE -|
+               ----> MODIFIED (local) ---> MODIFIED_THEIR_PLUS_MINE
+   
+        Steps performed on MODIFIED (local) file:
+        1. undo local changes MODIFIED -> BASE
+        2. apply changes from MODIFIED_THEIR
+        3. apply rebased local changes and create MODIFIED_THEIR_PLUS_MINE
+ 
+        Note, when rebase is not successfull, modified could be in random state.
+        This works in general, even when base==modified, or base==modified_theirs
+        
+         \param base [input] BASE sqlite3/geopackage file
+         \param modified_their [input] MODIFIED sqlite3/geopackage file
+         \param modified [input] local copy of the changes to be rebased
+         \param conflict [output] file where the automatically resolved conflicts are stored
+         \returns number of conflicts
+         
+         raises SqliteDiffError on error
+    """
+    def rebase(self, base, modified_their, modified, conflict):
+        return self.clib.rebase(base, modified_their, modified, conflict)
+
+    """ 
         Creates changeset file (binary) in such way that
         if CHANGESET is applied to MODIFIED_THEIR by
         applyChangeset, the new state will contain all
         changes from MODIFIED and MODIFIED_THEIR.
-        
+
                --- CHANGESET_THEIR ---> MODIFIED_THEIR --- CHANGESET ---> MODIFIED_THEIR_PLUS_MINE
         BASE -| 
                -----------------------> MODIFIED
-        
+
          \param base [input] BASE sqlite3/geopackage file
          \param modified [input] MODIFIED sqlite3/geopackage file
          \param changeset_their [input] changeset between BASE -> MODIFIED_THEIR
          \param changeset [output] changeset between MODIFIED_THEIR -> MODIFIED_THEIR_PLUS_MINE
-         
+         \param conflict [output] file where the automatically resolved conflicts are stored
+         \returns number of conflicts
+
          raises SqliteDiffError on error
     """
-
-    def rebase(self, base, modified_their, modified):
-        return self.clib.rebase(base, modified_their, modified)
-
-    def create_rebased_changeset(self, base, modified, changeset_their, changeset):
-        return self.clib.create_rebased_changeset(base, modified, changeset_their, changeset)
+    def create_rebased_changeset(self, base, modified, changeset_their, changeset, conflict):
+        return self.clib.create_rebased_changeset(base, modified, changeset_their, changeset, conflict)
 
     """
         Applies changeset file (binary) to BASE
         
         \param base [input/output] BASE sqlite3/geopackage file
         \param changeset [input] changeset to apply to BASE
-        \returns number of conflics
+        \returns number of conflicts
         
         raises SqliteDiffError on error
     """

--- a/pygeodiff/main.py
+++ b/pygeodiff/main.py
@@ -12,167 +12,162 @@ from .geodifflib import GeoDiffLib
 
 class GeoDiff:
     """
-        if libname is None, it tries to import c-extension from wheel
-        messages are shown in stdout. Use environment variable GEODIFF_LOGGER_LEVEL 0(Nothing)-4(Debug) to
-        set level (Errors by default)
+        geodiff is a module to create and apply changesets to GIS files (geopackage)
     """
+    
     def __init__(self, libname=None):
+        """
+            if libname is None, it tries to import c-extension from wheel
+            messages are shown in stdout. Use environment variable GEODIFF_LOGGER_LEVEL 0(Nothing)-4(Debug) to
+            set level (Errors by default)
+        """
         self.clib = GeoDiffLib(libname)
 
-    """
-     Assign custom logger
-     Replace default stdout logger with custom.
-     Based on maxLogLevel, the messages are filtered by level:
-     maxLogLevel = 0 nothing is passed to logger callback
-     maxLogLevel = 1 errors are passed to logger callback
-     maxLogLevel = 2 errors and warnings are passed to logger callback
-     maxLogLevel = 3 errors, warnings and infos are passed to logger callback
-     maxLogLevel = 4 errors, warnings, infos, debug messages are passed to logger callback
-    """
     def set_logging(self, callback, maxLevel):
+        """
+         Assign custom logger
+         Replace default stdout logger with custom.
+         Based on maxLogLevel, the messages are filtered by level:
+         maxLogLevel = 0 nothing is passed to logger callback
+         maxLogLevel = 1 errors are passed to logger callback
+         maxLogLevel = 2 errors and warnings are passed to logger callback
+         maxLogLevel = 3 errors, warnings and infos are passed to logger callback
+         maxLogLevel = 4 errors, warnings, infos, debug messages are passed to logger callback
+        """
         return self.clib.set_logging(callback, maxLevel)
 
-    """
-        Creates changeset file (binary) in such way that
-        if CHANGESET is applied to BASE by applyChangeset,
-        MODIFIED will be created
-
-        BASE --- CHANGESET ---> MODIFIED
-
-        \param base [input] BASE sqlite3/geopackage file
-        \param modified [input] MODIFIED sqlite3/geopackage file
-        \param changeset [output] changeset between BASE -> MODIFIED
-
-        raises SqliteDiffError on error
-    """
     def create_changeset(self, base, modified, changeset):
+        """
+            Creates changeset file (binary) in such way that
+            if CHANGESET is applied to BASE by applyChangeset,
+            MODIFIED will be created
+
+            BASE --- CHANGESET ---> MODIFIED
+
+            \param base [input] BASE sqlite3/geopackage file
+            \param modified [input] MODIFIED sqlite3/geopackage file
+            \param changeset [output] changeset between BASE -> MODIFIED
+
+            raises SqliteDiffError on error
+        """
         return self.clib.create_changeset(base, modified, changeset)
 
-    """
-        Inverts changeset file (binary) in such way that
-        if CHANGESET_INV is applied to MODIFIED by applyChangeset,
-        BASE will be created
-
-        \param changeset [input] changeset between BASE -> MODIFIED
-        \param changeset_inv [output] changeset between MODIFIED -> BASE
-        
-        \returns number of conflics
-
-        raises SqliteDiffError on error
-    """
-
     def invert_changeset(self, changeset, changeset_inv):
+        """
+            Inverts changeset file (binary) in such way that
+            if CHANGESET_INV is applied to MODIFIED by applyChangeset,
+            BASE will be created
+
+            \param changeset [input] changeset between BASE -> MODIFIED
+            \param changeset_inv [output] changeset between MODIFIED -> BASE
+
+            \returns number of conflics
+
+            raises SqliteDiffError on error
+        """
         return self.clib.invert_changeset(changeset, changeset_inv)
 
-    """ 
-        Rebases local modified version from base to modified_their version
-  
-               --- > MODIFIED_THEIR
-        BASE -|
-               ----> MODIFIED (local) ---> MODIFIED_THEIR_PLUS_MINE
-   
-        Steps performed on MODIFIED (local) file:
-        1. undo local changes MODIFIED -> BASE
-        2. apply changes from MODIFIED_THEIR
-        3. apply rebased local changes and create MODIFIED_THEIR_PLUS_MINE
- 
-        Note, when rebase is not successfull, modified could be in random state.
-        This works in general, even when base==modified, or base==modified_theirs
-        
-         \param base [input] BASE sqlite3/geopackage file
-         \param modified_their [input] MODIFIED sqlite3/geopackage file
-         \param modified [input] local copy of the changes to be rebased
-         \param conflict [output] file where the automatically resolved conflicts are stored
-         \returns number of conflicts
-         
-         raises SqliteDiffError on error
-    """
     def rebase(self, base, modified_their, modified, conflict):
+        """
+            Rebases local modified version from base to modified_their version
+
+                   --- > MODIFIED_THEIR
+            BASE -|
+                   ----> MODIFIED (local) ---> MODIFIED_THEIR_PLUS_MINE
+
+            Steps performed on MODIFIED (local) file:
+            1. undo local changes MODIFIED -> BASE
+            2. apply changes from MODIFIED_THEIR
+            3. apply rebased local changes and create MODIFIED_THEIR_PLUS_MINE
+
+            Note, when rebase is not successfull, modified could be in random state.
+            This works in general, even when base==modified, or base==modified_theirs
+
+             \param base [input] BASE sqlite3/geopackage file
+             \param modified_their [input] MODIFIED sqlite3/geopackage file
+             \param modified [input] local copy of the changes to be rebased
+             \param conflict [output] file where the automatically resolved conflicts are stored
+             \returns number of conflicts
+
+             raises SqliteDiffError on error
+        """
         return self.clib.rebase(base, modified_their, modified, conflict)
 
-    """ 
-        Creates changeset file (binary) in such way that
-        if CHANGESET is applied to MODIFIED_THEIR by
-        applyChangeset, the new state will contain all
-        changes from MODIFIED and MODIFIED_THEIR.
-
-               --- CHANGESET_THEIR ---> MODIFIED_THEIR --- CHANGESET ---> MODIFIED_THEIR_PLUS_MINE
-        BASE -| 
-               -----------------------> MODIFIED
-
-         \param base [input] BASE sqlite3/geopackage file
-         \param modified [input] MODIFIED sqlite3/geopackage file
-         \param changeset_their [input] changeset between BASE -> MODIFIED_THEIR
-         \param changeset [output] changeset between MODIFIED_THEIR -> MODIFIED_THEIR_PLUS_MINE
-         \param conflict [output] file where the automatically resolved conflicts are stored
-         \returns number of conflicts
-
-         raises SqliteDiffError on error
-    """
     def create_rebased_changeset(self, base, modified, changeset_their, changeset, conflict):
+        """
+            Creates changeset file (binary) in such way that
+            if CHANGESET is applied to MODIFIED_THEIR by
+            applyChangeset, the new state will contain all
+            changes from MODIFIED and MODIFIED_THEIR.
+
+                   --- CHANGESET_THEIR ---> MODIFIED_THEIR --- CHANGESET ---> MODIFIED_THEIR_PLUS_MINE
+            BASE -|
+                   -----------------------> MODIFIED
+
+             \param base [input] BASE sqlite3/geopackage file
+             \param modified [input] MODIFIED sqlite3/geopackage file
+             \param changeset_their [input] changeset between BASE -> MODIFIED_THEIR
+             \param changeset [output] changeset between MODIFIED_THEIR -> MODIFIED_THEIR_PLUS_MINE
+             \param conflict [output] file where the automatically resolved conflicts are stored
+             \returns number of conflicts
+
+             raises SqliteDiffError on error
+        """
         return self.clib.create_rebased_changeset(base, modified, changeset_their, changeset, conflict)
 
-    """
-        Applies changeset file (binary) to BASE
-        
-        \param base [input/output] BASE sqlite3/geopackage file
-        \param changeset [input] changeset to apply to BASE
-        \returns number of conflicts
-        
-        raises SqliteDiffError on error
-    """
     def apply_changeset(self, base, changeset):
+        """
+            Applies changeset file (binary) to BASE
+
+            \param base [input/output] BASE sqlite3/geopackage file
+            \param changeset [input] changeset to apply to BASE
+            \returns number of conflicts
+
+            raises SqliteDiffError on error
+        """
         return self.clib.apply_changeset(base, changeset)
 
-    """ 
-        Lists changeset content JSON file
-        JSON contains all changes in human/machine readable name
-        \returns number of changes
-         
-         raises SqliteDiffError on error
-    """
     def list_changes(self, changeset, json):
+        """
+            Lists changeset content JSON file
+            JSON contains all changes in human/machine readable name
+            \returns number of changes
+
+             raises SqliteDiffError on error
+        """
         return self.clib.list_changes(changeset, json)
 
-    """ 
-        \returns whether changeset contains at least one change
-        
-        raises SqliteDiffError on error
-    """
-
-    """ 
-        Lists changeset summary content JSON file 
-        JSON contains a list of how many inserts/edits/deletes is contained in changeset for each table
-        \returns number of changes
-
-         raises SqliteDiffError on error
-    """
-
     def list_changes_summary(self, changeset, json):
+        """
+            Lists changeset summary content JSON file
+            JSON contains a list of how many inserts/edits/deletes is contained in changeset for each table
+            \returns number of changes
+
+             raises SqliteDiffError on error
+        """
         return self.clib.list_changes_summary(changeset, json)
 
-    """ 
-        \returns whether changeset contains at least one change
-
-        raises SqliteDiffError on error
-    """
 
     def has_changes(self, changeset):
+        """
+            \returns whether changeset contains at least one change
+
+            raises SqliteDiffError on error
+        """
         return self.clib.has_changes(changeset)
 
-    """ 
-        \returns number of changes
-
-         raises SqliteDiffError on error
-    """
-
     def changes_count(self, changeset):
+        """
+            \returns number of changes
+
+             raises SqliteDiffError on error
+        """
         return self.clib.changes_count(changeset)
 
-    """
-       geodiff version
-    """
     def version(self):
+        """
+            geodiff version
+        """
         return self.clib.version()
 
 

--- a/pygeodiff/tests/test_concurrent_commits.py
+++ b/pygeodiff/tests/test_concurrent_commits.py
@@ -34,10 +34,10 @@ class UnitTestsPythonConcurrentCommits(GeoDiffTests):
         check_nchanges(self.geodiff, changesetbaseA,  2)
 
         print("create changeset A to B")
-        n_conflicts =  self.geodiff.create_rebased_changeset(base, modifiedB, changesetbaseA, changesetAB, conflictAB)
+        self.geodiff.create_rebased_changeset(base, modifiedB, changesetbaseA, changesetAB, conflictAB)
         check_nchanges(self.geodiff, changesetAB, 2)
-        if n_conflicts != 0:
-            raise TestError("expected no conflict, got " + str(n_conflicts))
+        if os.path.exists(conflictAB):
+            raise TestError("expected no conflicts")
 
         print("apply changeset to A to get AB")
         shutil.copyfile(modifiedA, patchedAB)
@@ -49,9 +49,9 @@ class UnitTestsPythonConcurrentCommits(GeoDiffTests):
 
         print("check direct rebase")
         shutil.copyfile(modifiedB, patchedAB2)
-        n_conflicts =  self.geodiff.rebase(base, modifiedA, patchedAB2, conflictAB2)
-        if n_conflicts != 0:
-            raise TestError("expected no conflict")
+        self.geodiff.rebase(base, modifiedA, patchedAB2, conflictAB2)
+        if os.path.exists(conflictAB2):
+            raise TestError("expected no conflicts")
 
         self.geodiff.create_changeset(base, patchedAB2, changesetAB2)
         check_nchanges(self.geodiff, changesetAB2,  3)

--- a/pygeodiff/tests/test_concurrent_commits.py
+++ b/pygeodiff/tests/test_concurrent_commits.py
@@ -22,18 +22,22 @@ class UnitTestsPythonConcurrentCommits(GeoDiffTests):
         modifiedB = testdir() + "/" + testname + "/" + "inserted_1_B.gpkg"
         changesetbaseA = tmpdir() + "/py" + testname + "/" + "changeset_base_to_A.bin"
         changesetAB = tmpdir() + "/py" + testname + "/" + "changeset_A_to_B.bin"
+        conflictAB = tmpdir() + "/py" + testname + "/" + "conflict_A_to_B.json"
         changesetBbase = tmpdir() + "/py" + testname + "/" + "changeset_B_to_base.bin"
         patchedAB = tmpdir() + "/py" + testname + "/" + "patched_AB.gpkg"
         patchedAB2 = tmpdir() + "/py" + testname + "/" + "patched_AB_2.gpkg"
         changesetAB2 = tmpdir() + "/py" + testname + "/" + "changeset_AB2.bin"
+        conflictAB2 = tmpdir() + "/py" + testname + "/" + "conflict_A_to_B2.json"
 
         print("create changeset base to A")
         self.geodiff.create_changeset(base, modifiedA, changesetbaseA)
         check_nchanges(self.geodiff, changesetbaseA,  2)
 
         print("create changeset A to B")
-        self.geodiff.create_rebased_changeset(base, modifiedB, changesetbaseA, changesetAB)
+        n_conflicts =  self.geodiff.create_rebased_changeset(base, modifiedB, changesetbaseA, changesetAB, conflictAB)
         check_nchanges(self.geodiff, changesetAB, 2)
+        if n_conflicts != 0:
+            raise TestError("expected no conflict, got " + str(n_conflicts))
 
         print("apply changeset to A to get AB")
         shutil.copyfile(modifiedA, patchedAB)
@@ -45,6 +49,9 @@ class UnitTestsPythonConcurrentCommits(GeoDiffTests):
 
         print("check direct rebase")
         shutil.copyfile(modifiedB, patchedAB2)
-        self.geodiff.rebase(base, modifiedA, patchedAB2)
+        n_conflicts =  self.geodiff.rebase(base, modifiedA, patchedAB2, conflictAB2)
+        if n_conflicts != 0:
+            raise TestError("expected no conflict")
+
         self.geodiff.create_changeset(base, patchedAB2, changesetAB2)
         check_nchanges(self.geodiff, changesetAB2,  3)


### PR DESCRIPTION
fix #38 

sample output (the same as with changeset JSON output, but with extra base and fid attribute)

```
{
   "geodiff": [
      {
        "table": "simple",
        "type": "conflict",
        "fid": "2",
        "changes": [
          {
              "column": 1,
              "base": "Point (-0.3638850889 0.5622435021)",
              "old": "Point (-0.9283697824 0.237870029)",
              "new": "Point (0.1752950386 2.046386324)"
          },
          {
              "column": 3,
              "base": null,
              "old": "9999",
              "new": null
          }
        ]
      }
   ]
}
```