### PR TITLE
[postgres] Update sequence objects if needed after applying changes

### DIFF
--- a/geodiff/src/drivers/postgresdriver.cpp
+++ b/geodiff/src/drivers/postgresdriver.cpp
@@ -819,7 +819,7 @@ void PostgresDriver::applyChangeset( ChangesetReader &reader )
   }
 
   // at the end, update any SEQUENCE objects if needed
-  for ( auto it : autoIncrementTablesToFix )
+  for ( const std::pair<std::string, int64_t> &it : autoIncrementTablesToFix )
     updateSequenceObject( tableNameToSequenceName[it.first], it.second );
 
   if ( !conflictCount )

--- a/geodiff/src/drivers/postgresdriver.h
+++ b/geodiff/src/drivers/postgresdriver.h
@@ -32,6 +32,8 @@ class PostgresDriver : public Driver
   private:
     void openPrivate( const DriverParametersMap &conn );
     void close();
+    std::string getSequenceObjectName( const TableSchema &tbl, int &autoIncrementPkeyIndex );
+    void updateSequenceObject( const std::string &seqName, int64_t maxValue );
 
     PGconn *mConn = nullptr;
     std::string mBaseSchema;

--- a/geodiff/src/geodiffutils.cpp
+++ b/geodiff/src/geodiffutils.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#include <cctype>
 #include <gpkg.h>
 
 #ifdef _WIN32

--- a/geodiff/src/tableschema.cpp
+++ b/geodiff/src/tableschema.cpp
@@ -8,9 +8,6 @@
 #include "geodifflogger.hpp"
 #include "geodiffutils.hpp"
 
-#include <algorithm>
-#include <cctype>
-
 
 bool TableSchema::hasPrimaryKey() const
 {

--- a/geodiff/tests/test_driver_postgres.cpp
+++ b/geodiff/tests/test_driver_postgres.cpp
@@ -407,7 +407,7 @@ TEST( PostgresDriverTest, test_create_postgres_from_sqlite )
   EXPECT_EQ( tblTest1.columns[2].type, "integer" );
   EXPECT_EQ( tblTest1.columns[3].type, "text" );
 
-  execSqlCommandsFromString( pgTestConnInfo(), "DROP SCHEMA gd_test_postgres_from_sqlite CASCADE;" );
+  execSqlCommandsFromString( pgTestConnInfo(), "DROP SCHEMA IF EXISTS gd_test_postgres_from_sqlite CASCADE;" );
 
   DriverParametersMap paramsBase;
   paramsBase["conninfo"] = pgTestConnInfo();


### PR DESCRIPTION
Like this, if a pkey has default value "nextval(...)" from a sequence object,
it will not try to use a value that has been taken in the meanwhile.

Fixes #65 