### PR TITLE
Add GEODIFF_rebaseEx to allow rebasing with postgres driver

### DIFF
--- a/geodiff/src/drivers/postgresdriver.cpp
+++ b/geodiff/src/drivers/postgresdriver.cpp
@@ -678,7 +678,11 @@ static std::string sqlForUpdate( const std::string &schemaName, const std::strin
       if ( !first )
         sql += " AND ";
       first = false;
-      sql += quotedIdentifier( tbl.columns[i].name ) + " = " + valueToSql( oldValues[i], tbl.columns[i] );
+      sql += quotedIdentifier( tbl.columns[i].name );
+      if ( oldValues[i].type() == Value::TypeNull )
+        sql += " IS NULL";
+      else
+        sql += " = " + valueToSql( oldValues[i], tbl.columns[i] );
     }
   }
 
@@ -795,7 +799,7 @@ void PostgresDriver::applyChangeset( ChangesetReader &reader )
       {
         logApplyConflict( "update_nothing", entry );
         ++conflictCount;
-        Logger::instance().warn( "Wrong number of affected rows! Expected 1, got: " + res.affectedRows() );
+        Logger::instance().warn( "Wrong number of affected rows! Expected 1, got: " + res.affectedRows() + "\nSQL: " + sql );
       }
     }
     else if ( entry.op == ChangesetEntry::OpDelete )

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -274,6 +274,33 @@ GEODIFF_EXPORT int GEODIFF_createChangesetEx( const char *driverName, const char
 GEODIFF_EXPORT int GEODIFF_applyChangesetEx( const char *driverName, const char *driverExtraInfo,
     const char *base, const char *changeset );
 
+
+/**
+ * This function takes an existing changeset "base2modified" and rebases it on top of changes in
+ * "base2their" and writes output to a new changeset "rebased"
+ */
+GEODIFF_EXPORT int GEODIFF_createRebasedChangesetEx(
+  const char *driverName,
+  const char *driverExtraInfo,
+  const char *base,
+  const char *base2modified,
+  const char *base2their,
+  const char *rebased,
+  const char *conflictfile );
+
+
+/**
+ * This function takes care of updating "modified" dataset by taking any changes between "base"
+ * and "modified" datasets and rebasing them on top of base2their changeset.
+ */
+GEODIFF_EXPORT int GEODIFF_rebaseEx(
+  const char *driverName,
+  const char *driverExtraInfo,
+  const char *base,
+  const char *modified,
+  const char *base2their,
+  const char *conflictfile );
+
 #ifdef __cplusplus
 }
 #endif

--- a/geodiff/src/geodiffinfo.cpp
+++ b/geodiff/src/geodiffinfo.cpp
@@ -25,6 +25,7 @@ void help()
   printf( "[make copy of a database/schema] geodiffinfo makeCopy driverSrcName driverSrcExtraInfo src driverDstName driverDstExtraInfo dst\n" );
   printf( "[create changeset with driver] geodiffinfo createChangesetEx driverName driverExtraInfo base modified changeset\n" );
   printf( "[apply changeset with driver] geodiffinfo applyChangesetEx driverName driverExtraInfo base changeset\n" );
+  printf( "[rebase data with driver] geodiffinfo rebaseEx driverName driverExtraInfo base modified base2their conflict\n" );
 }
 
 int err( const std::string msg )
@@ -122,6 +123,17 @@ int applyChangesetEx( int argc, char *argv[] )
   return ret;
 }
 
+int rebaseEx( int argc, char *argv[] )
+{
+  if ( argc < 1 + 7 )
+  {
+    return err( "invalid number of arguments to rebaseEx" );
+  }
+
+  int ret = GEODIFF_rebaseEx( argv[2], argv[3], argv[4], argv[5], argv[6], argv[7] );
+  return ret;
+}
+
 int main( int argc, char *argv[] )
 {
   GEODIFF_init();
@@ -170,6 +182,10 @@ int main( int argc, char *argv[] )
     else if ( mode == "applyChangesetEx" )
     {
       return applyChangesetEx( argc, argv );
+    }
+    else if ( mode == "rebaseEx" )
+    {
+      return rebaseEx( argc, argv );
     }
     else
     {

--- a/geodiff/src/geodiffutils.cpp
+++ b/geodiff/src/geodiffutils.cpp
@@ -560,3 +560,21 @@ std::string lowercaseString( const std::string &str )
   []( unsigned char c ) { return std::tolower( c ); } );
   return ret;
 }
+
+
+// from https://stackoverflow.com/questions/440133/how-do-i-create-a-random-alpha-numeric-string-in-c
+std::string randomString( size_t length )
+{
+  auto randchar = []() -> char
+  {
+    const char charset[] =
+    "0123456789"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz";
+    const size_t max_index = ( sizeof( charset ) - 1 );
+    return charset[ rand() % max_index ];
+  };
+  std::string str( length, 0 );
+  std::generate_n( str.begin(), length, randchar );
+  return str;
+}

--- a/geodiff/src/geodiffutils.hpp
+++ b/geodiff/src/geodiffutils.hpp
@@ -115,6 +115,9 @@ std::string getEnvVar( std::string const &key, const std::string &defaultVal );
 //! Returns temporary directory (including trailing slash)
 std::string tmpdir();
 
+//! Returns string given number of random alpha-numeric characters
+std::string randomString( size_t length );
+
 
 class TmpFile
 {

--- a/geodiff/src/tableschema.cpp
+++ b/geodiff/src/tableschema.cpp
@@ -71,7 +71,8 @@ void tableSchemaSqliteToPostgres( TableSchema &tbl )
     // substring in data type name implies integer affinity, "DOUB" substring implies real number
     // affinity. (But columns can contain any data value type anyway.)
 
-    if ( col.type == "int" || col.type == "integer" || col.type == "smallint" || col.type == "mediumint" || col.type == "bigint" )
+    if ( col.type == "int" || col.type == "integer" || col.type == "smallint" ||
+         col.type == "mediumint" || col.type == "bigint" || col.type == "tinyint" )
     {
       col.type = "integer";
     }
@@ -83,7 +84,7 @@ void tableSchemaSqliteToPostgres( TableSchema &tbl )
     {
       col.type = "boolean";
     }
-    else if ( col.type.rfind( "text(" ) == 0 || col.type.rfind( "varchar(" ) == 0 )
+    else if ( col.type == "text" || col.type.rfind( "text(" ) == 0 || col.type.rfind( "varchar(" ) == 0 )
     {
       col.type = "text";
     }

--- a/geodiff/tests/testdata/postgres/inserted_1_b.sql
+++ b/geodiff/tests/testdata/postgres/inserted_1_b.sql
@@ -1,0 +1,11 @@
+
+DROP SCHEMA IF EXISTS gd_inserted_1_b CASCADE;
+
+CREATE SCHEMA gd_inserted_1_b;
+
+CREATE TABLE gd_inserted_1_b.simple ( "fid" SERIAL PRIMARY KEY, "geometry" GEOMETRY(POINT, 4326), "name" TEXT, "rating" INTEGER);
+
+INSERT INTO gd_inserted_1_b.simple VALUES (1, ST_GeomFromText('Point (-1.08891928864569065 0.46101231190150482)', 4326), 'feature1', 1);
+INSERT INTO gd_inserted_1_b.simple VALUES (2, ST_GeomFromText('Point (-0.36388508891928861 0.56224350205198359)', 4326), 'feature2', 2);
+INSERT INTO gd_inserted_1_b.simple VALUES (3, ST_GeomFromText('Point (-0.73050615595075241 0.04240766073871405)', 4326), 'feature3', 3);
+INSERT INTO gd_inserted_1_b.simple VALUES (4, ST_GeomFromText('Point (-0.83257081666079680 0.16881887690991337)', 4326), 'my new point B', 2);


### PR DESCRIPTION
This is needed for DB sync...

Also includes minor improvements in handling handling sqlite-postgres table schema conversion and fixes applyChangeset for postgres when a value is NULL