### PR TITLE
Add C and Python API to access content of changeset files

### DIFF
--- a/geodiff/src/changesetreader.cpp
+++ b/geodiff/src/changesetreader.cpp
@@ -60,6 +60,10 @@ bool ChangesetReader::nextEntry( ChangesetEntry &entry )
       entry.table = &mCurrentTable;
       return true;  // we're done!
     }
+    else
+    {
+      throwReaderError( "Unknown entry type " + std::to_string( type ) );
+    }
   }
   return false;
 }

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -657,6 +657,12 @@ int GEODIFF_dumpData( const char *driverName, const char *driverExtraInfo, const
 
 GEODIFF_ChangesetReaderH GEODIFF_readChangeset( const char *changeset )
 {
+  if ( !changeset )
+  {
+    Logger::instance().error( "NULL changeset argument to GEODIFF_readChangeset" );
+    return nullptr;
+  }
+
   ChangesetReader *reader = new ChangesetReader;
   if ( !reader->open( changeset ) )
   {

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -6,6 +6,8 @@
 #ifndef GEODIFF_H
 #define GEODIFF_H
 
+#include <stdint.h>
+
 #ifdef GEODIFF_STATIC
 #  define GEODIFF_EXPORT
 #else
@@ -324,6 +326,135 @@ GEODIFF_EXPORT int GEODIFF_rebaseEx(
  */
 GEODIFF_EXPORT int GEODIFF_dumpData( const char *driverName, const char *driverExtraInfo,
                                      const char *src, const char *changeset );
+
+
+typedef void *GEODIFF_ChangesetReaderH;
+typedef void *GEODIFF_ChangesetEntryH;
+typedef void *GEODIFF_ChangesetTableH;
+typedef void *GEODIFF_ValueH;
+
+/**
+ * Tries to open a changeset file and returns a new changeset reader object if successful,
+ * or null if it failed (the file does not exist, unknown format, ...) The ownership
+ * of the returned object is passed to the caller - GEODIFF_CR_destroy() should be called
+ * when the reader is not needed anymore.
+ */
+GEODIFF_EXPORT GEODIFF_ChangesetReaderH GEODIFF_readChangeset( const char *changeset );
+
+//
+// ChangesetReader-related functions
+//
+
+/**
+ * Returns the next entry from the changeset reader, or null if there are no more entries.
+ * The ownership of the returned entry is passed to the caller - GEODIFF_CE_destroy() should
+ * be called when the entry is not needed anymore.
+ *
+ * If an exception has occurred (e.g. bad file content), the passed "ok" variable will be set
+ * to false. Normally it will be set to true (even we have reached the end of the file).
+ */
+GEODIFF_EXPORT GEODIFF_ChangesetEntryH GEODIFF_CR_nextEntry( GEODIFF_ChangesetReaderH reader, bool *ok );
+
+/**
+ * Deletes an existing changeset reader object and frees any resources related to it.
+ */
+GEODIFF_EXPORT void GEODIFF_CR_destroy( GEODIFF_ChangesetReaderH reader );
+
+//
+// ChangesetEntry-related functions
+//
+
+/**
+ * Reads entry's operation type - whether it is an insert, update or delete.
+ */
+GEODIFF_EXPORT int GEODIFF_CE_operation( GEODIFF_ChangesetEntryH entry );
+
+/**
+ * Returns table-related information object of the entry. The returned object is owned
+ * by geodiff and does not need to be deleted by the caller. It is only valid while
+ * the changeset entry is not deleted.
+ */
+GEODIFF_EXPORT GEODIFF_ChangesetTableH GEODIFF_CE_table( GEODIFF_ChangesetEntryH entry );
+
+/**
+ * Returns number of items in the list of old/new values.
+ */
+GEODIFF_EXPORT int GEODIFF_CE_countValues( GEODIFF_ChangesetEntryH entry );
+
+/**
+ * Returns old value of an entry (only valid for UPDATE and DELETE).
+ * The ownership of the value object is passed to the caller - GEODIFF_V_destroy()
+ * should be called when the value object is not needed anymore.
+ */
+GEODIFF_EXPORT GEODIFF_ValueH GEODIFF_CE_oldValue( GEODIFF_ChangesetEntryH entry, int i );
+
+/**
+ * Returns new value of an entry (only valid for UPDATE and INSERT).
+ * The ownership of the value object is passed to the caller - GEODIFF_V_destroy()
+ * should be called when the value object is not needed anymore.
+ */
+GEODIFF_EXPORT GEODIFF_ValueH GEODIFF_CE_newValue( GEODIFF_ChangesetEntryH entry, int i );
+
+/**
+ * Deletes an existing changeset entry object and frees any resources related to it.
+ */
+GEODIFF_EXPORT void GEODIFF_CE_destroy( GEODIFF_ChangesetEntryH entry );
+
+//
+// ChangesetTable-related functions
+//
+
+/**
+ * Returns name of the table. Ownership of the returned pointer is NOT passed to the caller
+ * and should not be modified or freed.
+ */
+GEODIFF_EXPORT const char *GEODIFF_CT_name( GEODIFF_ChangesetTableH table );
+
+/**
+ * Returns number of columns in the table.
+ */
+GEODIFF_EXPORT int GEODIFF_CT_columnCount( GEODIFF_ChangesetTableH table );
+
+/**
+ * Returns whether column at the given index is a part of the table's primary key.
+ */
+GEODIFF_EXPORT bool GEODIFF_CT_columnIsPkey( GEODIFF_ChangesetTableH table, int i );
+
+
+//
+// Value-related functions
+//
+
+/**
+ * Returns type of the value stored in the object
+ */
+GEODIFF_EXPORT int GEODIFF_V_type( GEODIFF_ValueH value );
+
+/**
+ * Returns integer value (if type is not TypeInt, the result is undefined)
+ */
+GEODIFF_EXPORT int64_t GEODIFF_V_getInt( GEODIFF_ValueH value );
+
+/**
+ * Returns double value (if type is not TypeDouble, the result is undefined)
+ */
+GEODIFF_EXPORT double GEODIFF_V_getDouble( GEODIFF_ValueH value );
+
+/**
+ * Returns number of bytes of text/blob value (if type is not TypeText or TypeBlob, the result is undefined)
+ */
+GEODIFF_EXPORT int GEODIFF_V_getDataSize( GEODIFF_ValueH value );
+
+/**
+ * Copies data of the text/blob value to given buffer (if type is not TypeText or TypeBlob, the result is undefined)
+ */
+GEODIFF_EXPORT void GEODIFF_V_getData( GEODIFF_ValueH value, char *data );
+
+/**
+ * Deletes an existing value object and frees any resources related to it.
+ */
+GEODIFF_EXPORT void GEODIFF_V_destroy( GEODIFF_ValueH value );
+
 
 #ifdef __cplusplus
 }

--- a/pygeodiff/__init__.py
+++ b/pygeodiff/__init__.py
@@ -12,5 +12,8 @@ from .geodifflib import (
     GeoDiffLibError,
     GeoDiffLibConflictError,
     GeoDiffLibUnsupportedChangeError,
-    GeoDiffLibVersionError
+    GeoDiffLibVersionError,
+    ChangesetEntry,
+    ChangesetReader,
+    UndefinedValue,
 )

--- a/pygeodiff/geodifflib.py
+++ b/pygeodiff/geodifflib.py
@@ -62,6 +62,81 @@ class GeoDiffLib:
         self.lib = ctypes.CDLL(self.libname, use_errno=True)
         self.init()
         self.check_version()
+        self._register_functions()
+
+    def _register_functions(self):
+        self._readChangeset = self.lib.GEODIFF_readChangeset
+        self._readChangeset.argtypes = [ctypes.c_char_p]
+        self._readChangeset.restype = ctypes.c_void_p
+
+        # ChangesetReader
+        self._CR_nextEntry = self.lib.GEODIFF_CR_nextEntry
+        self._CR_nextEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        self._CR_nextEntry.restype = ctypes.c_void_p
+
+        self._CR_destroy = self.lib.GEODIFF_CR_destroy
+        self._CR_destroy.argtypes = [ctypes.c_void_p]
+
+        # ChangesetEntry
+        self._CE_operation = self.lib.GEODIFF_CE_operation
+        self._CE_operation.argtypes = [ctypes.c_void_p]
+        self._CE_operation.restype = ctypes.c_int
+
+        self._CE_table = self.lib.GEODIFF_CE_table
+        self._CE_table.argtypes = [ctypes.c_void_p]
+        self._CE_table.restype = ctypes.c_void_p
+
+        self._CE_count = self.lib.GEODIFF_CE_countValues
+        self._CE_count.argtypes = [ctypes.c_void_p]
+        self._CE_count.restype = ctypes.c_int
+
+        self._CE_old_value = self.lib.GEODIFF_CE_oldValue
+        self._CE_old_value.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self._CE_old_value.restype = ctypes.c_void_p
+
+        self._CE_new_value = self.lib.GEODIFF_CE_newValue
+        self._CE_new_value.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self._CE_new_value.restype = ctypes.c_void_p
+
+        self._CE_destroy = self.lib.GEODIFF_CE_destroy
+        self._CE_destroy.argtypes = [ctypes.c_void_p]
+
+        # ChangesetTable
+        self._CT_name = self.lib.GEODIFF_CT_name
+        self._CT_name.argtypes = [ctypes.c_void_p]
+        self._CT_name.restype = ctypes.c_char_p
+
+        self._CT_column_count = self.lib.GEODIFF_CT_columnCount
+        self._CT_column_count.argtypes = [ctypes.c_void_p]
+        self._CT_column_count.restype = ctypes.c_int
+
+        self._CT_column_is_pkey = self.lib.GEODIFF_CT_columnIsPkey
+        self._CT_column_is_pkey.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        self._CT_column_is_pkey.restype = ctypes.c_bool
+
+        # Value
+        self._V_type = self.lib.GEODIFF_V_type
+        self._V_type.argtypes = [ctypes.c_void_p]
+        self._V_type.restype = ctypes.c_int
+
+        self._V_get_int = self.lib.GEODIFF_V_getInt
+        self._V_get_int.argtypes = [ctypes.c_void_p]
+        self._V_get_int.restype = ctypes.c_int
+
+        self._V_get_double = self.lib.GEODIFF_V_getDouble
+        self._V_get_double.argtypes = [ctypes.c_void_p]
+        self._V_get_double.restype = ctypes.c_double
+
+        self._V_get_data_size = self.lib.GEODIFF_V_getDataSize
+        self._V_get_data_size.argtypes = [ctypes.c_void_p]
+        self._V_get_data_size.restype = ctypes.c_int
+
+        self._V_get_data = self.lib.GEODIFF_V_getData
+        self._V_get_data.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+        self._V_destroy = self.lib.GEODIFF_V_destroy
+        self._V_destroy.argtypes = [ctypes.c_void_p]
+
 
     def package_libname(self):
         # assume that the package is installed through PIP
@@ -109,7 +184,7 @@ class GeoDiffLib:
         cversion = self.version()
         pyversion = __version__
         if cversion != pyversion:
-            raise GeoDiffLibVersionError("version mismatch (%s C vs %s PY)".format(cversion, pyversion))
+            raise GeoDiffLibVersionError("version mismatch ({} C vs {} PY)".format(cversion, pyversion))
 
     def create_changeset(self, base, modified, changeset):
         func = self.lib.GEODIFF_createChangeset
@@ -239,3 +314,123 @@ class GeoDiffLib:
 
         res = func(b_string1, b_string2, b_string3, b_string4, b_string5, b_string6, b_string7)
         _parse_return_code( res, "CreateChangesetDr" )
+
+    def read_changeset(self, changeset):
+
+        b_string1 = changeset.encode('utf-8')
+
+        reader_ptr = self._readChangeset(b_string1)
+        if reader_ptr is None:
+            raise GeoDiffLibError("Unable to open reader for: " + changeset)
+        return ChangesetReader(self, reader_ptr)
+
+
+class ChangesetReader(object):
+    """ Wrapper around GEODIFF_CR_* functions from C API """
+
+    def __init__(self, geodiff, reader_ptr):
+        self.geodiff = geodiff
+        self.reader_ptr = reader_ptr
+
+    def __del__(self):
+        self.geodiff._CR_destroy(self.reader_ptr)
+
+    def next_entry(self):
+        ok = ctypes.c_bool()
+        entry_ptr = self.geodiff._CR_nextEntry(self.reader_ptr, ctypes.byref(ok))
+        if not ok:
+            raise GeoDiffLibError("Failed to read entry!")
+        if entry_ptr is not None:
+            return ChangesetEntry(self.geodiff, entry_ptr)
+        else:
+            return None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        entry = self.next_entry()
+        if entry is not None:
+            return entry
+        else:
+            raise StopIteration
+
+
+class ChangesetEntry(object):
+    """ Wrapper around GEODIFF_CE_* functions from C API """
+
+    # constants as defined in ChangesetEntry::OperationType enum
+    OP_INSERT = 18
+    OP_UPDATE = 23
+    OP_DELETE = 9
+
+    def __init__(self, geodiff, entry_ptr):
+        self.geodiff = geodiff
+        self.entry_ptr = entry_ptr
+
+        self.operation = self.geodiff._CE_operation(self.entry_ptr)
+        self.values_count = self.geodiff._CE_count(self.entry_ptr)
+
+        if self.operation == self.OP_DELETE or self.operation == self.OP_UPDATE:
+            self.old_values = []
+            for i in range(self.values_count):
+                v_ptr = self.geodiff._CE_old_value(self.entry_ptr, i)
+                self.old_values.append(self._convert_value(v_ptr))
+
+        if self.operation == self.OP_INSERT or self.operation == self.OP_UPDATE:
+            self.new_values = []
+            for i in range(self.values_count):
+                v_ptr = self.geodiff._CE_new_value(self.entry_ptr, i)
+                self.new_values.append(self._convert_value(v_ptr))
+
+        table = self.geodiff._CE_table(entry_ptr)
+        self.table = ChangesetTable(geodiff, table)
+
+    def __del__(self):
+        self.geodiff._CE_destroy(self.entry_ptr)
+
+    def _convert_value(self, v_ptr):
+        v_type = self.geodiff._V_type(v_ptr)
+        if v_type == 0:
+            v_val = UndefinedValue()
+        elif v_type == 1:
+            v_val = self.geodiff._V_get_int(v_ptr)
+        elif v_type == 2:
+            v_val = self.geodiff._V_get_double(v_ptr)
+        elif v_type == 3 or v_type == 4:  # 3==text, 4==blob
+            size = self.geodiff._V_get_data_size(v_ptr)
+            buffer = ctypes.create_string_buffer(size)
+            self.geodiff._V_get_data(v_ptr, buffer)
+            v_val = buffer.raw
+            if v_type == 3:
+                v_val = v_val.decode('utf-8')
+        elif v_type == 5:
+            v_val = None
+        else:
+            raise GeoDiffLibError("unknown value type {}".format(v_type))
+        self.geodiff._V_destroy(v_ptr)
+        return v_val
+
+
+class ChangesetTable(object):
+    """ Wrapper around GEODIFF_CT_* functions from C API """
+
+    def __init__(self, geodiff, table_ptr):
+        self.geodiff = geodiff
+        self.table_ptr = table_ptr
+
+        self.name = self.geodiff._CT_name(table_ptr).decode('utf-8')
+        self.column_count = self.geodiff._CT_column_count(table_ptr)
+        self.column_is_pkey = []
+        for i in range(self.column_count):
+            self.column_is_pkey.append(self.geodiff._CT_column_is_pkey(table_ptr, i))
+
+
+class UndefinedValue(object):
+    """ Marker that a value in changeset is undefined. This is different
+    from NULL value (which is represented as None). Undefined values are
+    used for example as values of columns in UPDATE operation that did
+    not get modified. """
+
+    def __repr__(self):
+        return "<N/A>"

--- a/pygeodiff/geodifflib.py
+++ b/pygeodiff/geodifflib.py
@@ -355,6 +355,8 @@ class ChangesetReader(object):
         else:
             raise StopIteration
 
+    next = __next__  # python 2.x compatibility (requires next())
+
 
 class ChangesetEntry(object):
     """ Wrapper around GEODIFF_CE_* functions from C API """

--- a/pygeodiff/main.py
+++ b/pygeodiff/main.py
@@ -196,6 +196,12 @@ class GeoDiff:
         """
         return self.clib.create_changeset_dr(driver_src, driver_src_info, src, driver_dst, driver_dst_info, dst, changeset)
 
+    def read_changeset(self, changeset):
+        """
+        Opens a changeset file and returns reader object or raises GeoDiffLibError on error.
+        """
+        return self.clib.read_changeset(changeset)
+
     def version(self):
         """
             geodiff version

--- a/pygeodiff/tests/test_changeset_reader.py
+++ b/pygeodiff/tests/test_changeset_reader.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+'''
+    :copyright: (c) 2021 Martin Dobias
+    :license: MIT, see LICENSE for more details.
+'''
+
+from .testutils import GeoDiffTests, testdir
+from pygeodiff import ChangesetEntry, ChangesetReader, GeoDiffLibError, UndefinedValue
+import os
+
+
+class UnitTestsChangesetReader(GeoDiffTests):
+
+    def test_invalid_file(self):
+        changeset = os.path.join(testdir(), "missing-file.diff")
+        with self.assertRaises(GeoDiffLibError):
+            ch_reader = self.geodiff.read_changeset(changeset)
+
+        # existing file, but wrong format... reader will be created fine
+        # (there's no header to verify it's the right file type)
+        changeset = os.path.join(testdir(), "base.gpkg")
+        ch_reader = self.geodiff.read_changeset(changeset)
+        with self.assertRaises(GeoDiffLibError):
+            ch_reader.next_entry()
+
+    def test_basic(self):
+        changeset = os.path.join(testdir(), "1_geopackage", "base-modified_1_geom.diff")
+        ch_reader = self.geodiff.read_changeset(changeset)
+        self.assertIsInstance(ch_reader, ChangesetReader)
+        entry = ch_reader.next_entry()
+        self.assertEqual(entry.operation, ChangesetEntry.OP_UPDATE)
+        entry = ch_reader.next_entry()
+        self.assertEqual(entry.operation, ChangesetEntry.OP_UPDATE)
+        entry = ch_reader.next_entry()
+        self.assertEqual(entry, None)
+
+    def test_iterator(self):
+        changeset = os.path.join(testdir(), "1_geopackage", "base-modified_1_geom.diff")
+        i = 0
+        for entry in self.geodiff.read_changeset(changeset):
+            self.assertEqual(entry.operation, ChangesetEntry.OP_UPDATE)
+            if i == 0:  # change in gpkg_contents
+                self.assertEqual(entry.table.name, 'gpkg_contents')
+                self.assertEqual(entry.old_values[0], 'simple')
+            else:  # change in 'simple' table
+                self.assertEqual(entry.table.name, 'simple')
+                self.assertEqual(entry.old_values[0], 1)
+                self.assertIsInstance(entry.new_values[0], UndefinedValue)
+                self.assertIsInstance(entry.old_values[1], bytes)
+                self.assertIsInstance(entry.new_values[1], bytes)
+                self.assertEqual(len(entry.old_values[1]), len(entry.new_values[1]))
+            i += 1
+        self.assertEqual(i, 2)
+
+    def test_insert(self):
+        changeset = os.path.join(testdir(), "2_inserts", "base-inserted_1_A.diff")
+        i = 0
+        for entry in self.geodiff.read_changeset(changeset):
+            self.assertEquals(entry.table.name, 'simple')
+            self.assertEquals(entry.new_values[0], 4)
+            self.assertEquals(entry.new_values[2], 'my new point A')
+            with self.assertRaises(AttributeError):
+                print(entry.old_values)   # with INSERT the "old_values" attribute is not set
+            i += 1
+        self.assertEqual(i, 1)
+
+    def test_delete(self):
+        changeset = os.path.join(testdir(), "2_deletes", "base-deleted_A.diff")
+        i = 0
+        for entry in self.geodiff.read_changeset(changeset):
+            self.assertEquals(entry.table.name, 'simple')
+            self.assertEquals(entry.old_values[0], 2)
+            self.assertEquals(entry.old_values[2], 'feature2')
+            with self.assertRaises(AttributeError):
+                print(entry.new_values)   # with DELETE the "new_values" attribute is not set
+            i += 1
+        self.assertEqual(i, 1)


### PR DESCRIPTION
Simple API to access changeset files:

```python
for entry in self.geodiff.read_changeset('/path/to/changeset.diff'):
    print('table:', entry.table.name)
    print('operation:', entry.operation)
    print('old values:', entry.old_values)   # valid for UPDATE / DELETE
    print('new values:', entry.new_values)   # valid for UPDATE / INSERT
```
