### PR TITLE
Add GEODIFF_concatChanges() to public API

### DIFF
--- a/geodiff/CMakeLists.txt
+++ b/geodiff/CMakeLists.txt
@@ -156,6 +156,7 @@ SET(geodiff_src
   src/geodifflogger.hpp
 
   src/changeset.h
+  src/changesetconcat.cpp
   src/changesetreader.cpp
   src/changesetreader.h
   src/changesetutils.cpp

--- a/geodiff/src/changesetconcat.cpp
+++ b/geodiff/src/changesetconcat.cpp
@@ -222,7 +222,9 @@ void concatChangesets( std::vector<std::string> filenames, std::string outputCha
         if ( entriesIt == t.entries.end() )
         {
           // row with this pkey is not in our list yet
-          t.entries.insert( new ChangesetEntry( entry ) );
+          ChangesetEntry *e = new ChangesetEntry( entry );
+          e->table = t.table.get();
+          t.entries.insert( e );
         }
         else
         {
@@ -235,10 +237,12 @@ void concatChangesets( std::vector<std::string> filenames, std::string outputCha
               break;   // nothing else to do - the original entry got updated in place
             case EntryRemoved:
               t.entries.erase( entriesIt );
+              delete entry0;
               break;
             case Unsupported:
               // we are discarding the new entry (there's no sensible way to integrate it)
               Logger::instance().warn( "concatChangesets: unsupported sequence of entries for a single row - discarding newer entry" );
+              delete entry0;
               break;
           }
         }

--- a/geodiff/src/changesetconcat.cpp
+++ b/geodiff/src/changesetconcat.cpp
@@ -192,12 +192,12 @@ static MergeEntriesResult mergeEntriesForRow( ChangesetEntry *e1, ChangesetEntry
 
 //! Concatenation of multiple changesets, based on the implementation from sqlite3session
 //! (functions sqlite3changegroup_add() and sqlite3changegroup_output())
-void concatChangesets( std::vector<std::string> filenames, std::string outputChangeset )
+void concatChangesets( const std::vector<std::string> &filenames, const std::string &outputChangeset )
 {
   // hashtable: table name -> ( fid -> changeset entry )
   std::unordered_map<std::string, TableChanges> result;
 
-  for ( std::string inputFilename : filenames )
+  for ( const std::string &inputFilename : filenames )
   {
     ChangesetReader reader;
     if ( !reader.open( inputFilename ) )

--- a/geodiff/src/changesetconcat.cpp
+++ b/geodiff/src/changesetconcat.cpp
@@ -1,0 +1,267 @@
+/*
+ GEODIFF - MIT License
+ Copyright (C) 2021 Martin Dobias
+*/
+
+#include "sqlite3.h"
+
+#include <string>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "geodifflogger.hpp"
+#include "geodiffutils.hpp"
+#include "changesetreader.h"
+#include "changesetwriter.h"
+
+
+//! Hash value generator based on primary keys to have ChangesetEntry used in std::unordered_set
+struct HashChangesetEntryPkey
+{
+  size_t operator()( const ChangesetEntry *pentry ) const
+  {
+    size_t h = 0;
+    const ChangesetEntry &entry = *pentry;
+    const std::vector<bool> &pkeys = entry.table->primaryKeys;
+    const std::vector<Value> &values = entry.op == ChangesetEntry::OpInsert ? entry.newValues : entry.oldValues;
+    for ( size_t i = 0; i < pkeys.size(); ++i )
+    {
+      if ( pkeys[i] )
+        h ^= std::hash<Value> {}( values[i] );
+    }
+    return h;
+  }
+};
+
+
+//! Exact equality check based on primary keys to have ChangesetEntry used in std::unordered_set
+struct EqualToChangesetEntryPkey
+{
+  bool operator()( const ChangesetEntry *plhs, const ChangesetEntry *prhs ) const
+  {
+    const ChangesetEntry &lhs = *plhs;
+    const ChangesetEntry &rhs = *prhs;
+    const std::vector<bool> &pkeys = lhs.table->primaryKeys;
+    const std::vector<Value> &lhsValues = lhs.op == ChangesetEntry::OpInsert ? lhs.newValues : lhs.oldValues;
+    const std::vector<Value> &rhsValues = rhs.op == ChangesetEntry::OpInsert ? rhs.newValues : rhs.oldValues;
+    for ( size_t i = 0; i < pkeys.size(); ++i )
+    {
+      if ( pkeys[i] && lhsValues[i] != rhsValues[i] )
+        return false;
+    }
+    return true;
+  }
+};
+
+typedef std::unordered_set<ChangesetEntry *, HashChangesetEntryPkey, EqualToChangesetEntryPkey> TableEntriesSet;
+
+//! Struct to keep information about table and its changes while concatenating
+struct TableChanges
+{
+  std::unique_ptr<ChangesetTable> table;
+  TableEntriesSet entries;
+};
+
+
+//! This is a helper function used by mergeUpdate().
+static Value mergeValue( const Value &vOne, const Value &vTwo )
+{
+  return vTwo.type() != Value::TypeUndefined ? vTwo : vOne;
+}
+
+
+//! This function is used to merge two UPDATE changes on the same row.
+//! Returns false if the two updates cancel each other and the resulting
+//! changeset entry can be discarded.
+static bool mergeUpdate(
+  const ChangesetTable &t,
+  const std::vector<Value> valuesOld1, const std::vector<Value> valuesOld2,
+  const std::vector<Value> valuesNew1, const std::vector<Value> valuesNew2,
+  std::vector<Value> &outputOld, std::vector<Value> &outputNew )
+{
+  bool bRequired = false;
+
+  for ( size_t i = 0; i < t.columnCount(); ++i )
+  {
+    Value vOld = mergeValue( valuesOld1[i], valuesOld2.size() ? valuesOld2[i] : Value() );
+    Value vNew = mergeValue( valuesNew1[i], valuesNew2.size() ? valuesNew2[i] : Value() );
+
+    // if there would be no actual changes after the merge, we would discard the merged update...
+    if ( vOld != vNew && !t.primaryKeys[i] )
+      bRequired = true;
+
+    // write OLD
+    if ( t.primaryKeys[i] || vOld != vNew )
+    {
+      outputOld.push_back( vOld );
+    }
+    else
+    {
+      outputOld.push_back( Value() );
+    }
+
+    // write NEW
+    if ( t.primaryKeys[i] || vOld == vNew )
+    {
+      outputNew.push_back( Value() );
+    }
+    else
+    {
+      outputNew.push_back( vNew );
+    }
+  }
+
+  return bRequired;
+}
+
+
+//! Possible outcomes of merging two changeset entries
+enum MergeEntriesResult
+{
+  EntryModified,   //!< the entry got updated within the merge (INSERT+UPDATE, UPDATE+UPDATE, UPDATE+DELETE, DELETE+INSERT)
+  EntryRemoved,    //!< the entry should be removed after the merge (INSERT+DELETE)
+  Unsupported,     //!< unexpected combination (INSERT+INSERT, UPDATE+INSERT, DELETE+UPDATE, DELETE+DELETE)
+};
+
+//! Takes two changeset entries e1 and e2 and merges their changes to e1 if possible.
+//! It is also possible that merging results in no change at all, or the change is not allowed
+static MergeEntriesResult mergeEntriesForRow( ChangesetEntry *e1, ChangesetEntry *e2 )
+{
+  // all these changes make no sense really, if they happen most likely something got broken
+  // (e.g. adding a row with the same pkey twice)
+  if ( ( e1->op == ChangesetEntry::OpInsert && e2->op == ChangesetEntry::OpInsert ) ||
+       ( e1->op == ChangesetEntry::OpUpdate && e2->op == ChangesetEntry::OpInsert ) ||
+       ( e1->op == ChangesetEntry::OpDelete && e2->op == ChangesetEntry::OpUpdate ) ||
+       ( e1->op == ChangesetEntry::OpDelete && e2->op == ChangesetEntry::OpDelete ) )
+    return Unsupported;
+
+  if ( e1->op == ChangesetEntry::OpInsert && e2->op == ChangesetEntry::OpDelete )
+    return EntryRemoved;
+
+  if ( e1->op == ChangesetEntry::OpInsert && e2->op == ChangesetEntry::OpUpdate )
+  {
+    // modify INSERT - update its values wherever the update has a newer value
+    for ( size_t i = 0; i < e1->table->columnCount(); ++i )
+    {
+      if ( e2->newValues[i].type() != Value::TypeUndefined )
+        e1->newValues[i] = e2->newValues[i];
+    }
+    return EntryModified;
+  }
+
+  if ( e1->op == ChangesetEntry::OpUpdate && e2->op == ChangesetEntry::OpUpdate )
+  {
+    // modify UPDATE
+    std::vector<Value> oldVals, newVals;
+    if ( !mergeUpdate( *e1->table, e2->oldValues, e1->oldValues, e1->newValues, e2->newValues, oldVals, newVals ) )
+      return EntryRemoved;
+    e1->oldValues = oldVals;
+    e1->newValues = newVals;
+    return EntryModified;
+  }
+
+  if ( e1->op == ChangesetEntry::OpUpdate && e2->op == ChangesetEntry::OpDelete )
+  {
+    // turn into DELETE, use old values from delete when update does not list them
+    e1->op = ChangesetEntry::OpDelete;
+    for ( size_t i = 0; i < e1->table->columnCount(); ++i )
+    {
+      if ( e1->oldValues[i].type() == Value::TypeUndefined )
+        e1->oldValues[i] = e2->oldValues[i];
+    }
+    return EntryModified;
+  }
+
+  if ( e1->op == ChangesetEntry::OpDelete && e2->op == ChangesetEntry::OpInsert )
+  {
+    // turn into UPDATE
+    std::vector<Value> oldVals, newVals;
+    if ( !mergeUpdate( *e1->table, e1->oldValues, {}, e2->newValues, {}, oldVals, newVals ) )
+      return EntryRemoved;
+    e1->op = ChangesetEntry::OpUpdate;
+    e1->oldValues = oldVals;
+    e1->newValues = newVals;
+    return EntryModified;
+  }
+
+  assert( false ); // all 9 possible cases are exhausted
+  return Unsupported;
+}
+
+
+//! Concatenation of multiple changesets, based on the implementation from sqlite3session
+//! (functions sqlite3changegroup_add() and sqlite3changegroup_output())
+void concatChangesets( std::vector<std::string> filenames, std::string outputChangeset )
+{
+  // hashtable: table name -> ( fid -> changeset entry )
+  std::unordered_map<std::string, TableChanges> result;
+
+  for ( std::string inputFilename : filenames )
+  {
+    ChangesetReader reader;
+    if ( !reader.open( inputFilename ) )
+      throw GeoDiffException( "concatChangesets: unable to open input file: " + inputFilename );
+
+    ChangesetEntry entry;
+    while ( reader.nextEntry( entry ) )
+    {
+      auto tableIt = result.find( entry.table->name );
+      if ( tableIt == result.end() )
+      {
+        TableChanges &t = result[ entry.table->name ];   // adds new entry
+        t.table.reset( new ChangesetTable( *entry.table ) );
+        ChangesetEntry *e = new ChangesetEntry( entry );
+        e->table = t.table.get();
+        t.entries.insert( e );
+      }
+      else
+      {
+        TableChanges &t = tableIt->second;
+        auto entriesIt = t.entries.find( &entry );
+        if ( entriesIt == t.entries.end() )
+        {
+          // row with this pkey is not in our list yet
+          t.entries.insert( new ChangesetEntry( entry ) );
+        }
+        else
+        {
+          // we need to merge the recorded entry with the new one
+          ChangesetEntry *entry0 = *entriesIt;
+          MergeEntriesResult mergeRes = mergeEntriesForRow( entry0, &entry );
+          switch ( mergeRes )
+          {
+            case EntryModified:
+              break;   // nothing else to do - the original entry got updated in place
+            case EntryRemoved:
+              t.entries.erase( entriesIt );
+              break;
+            case Unsupported:
+              // we are discarding the new entry (there's no sensible way to integrate it)
+              Logger::instance().warn( "concatChangesets: unsupported sequence of entries for a single row - discarding newer entry" );
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  ChangesetWriter writer;
+  if ( !writer.open( outputChangeset ) )
+    throw GeoDiffException( "concatChangesets: unable to open output file: " + outputChangeset );
+
+  // output all we have captured
+  for ( auto it = result.begin(); it != result.end(); ++it )
+  {
+    TableChanges &t = it->second;
+    if ( t.entries.size() == 0 )
+      continue;
+
+    writer.beginTable( *t.table );
+    for ( ChangesetEntry *e : t.entries )
+    {
+      writer.writeEntry( *e );
+      delete e;
+    }
+  }
+}

--- a/geodiff/src/changesetreader.cpp
+++ b/geodiff/src/changesetreader.cpp
@@ -53,8 +53,12 @@ bool ChangesetReader::nextEntry( ChangesetEntry &entry )
       int indirect = readByte();
       if ( type != ChangesetEntry::OpInsert )
         readRowValues( entry.oldValues );
+      else
+        entry.oldValues.erase( entry.oldValues.begin(), entry.oldValues.end() );
       if ( type != ChangesetEntry::OpDelete )
         readRowValues( entry.newValues );
+      else
+        entry.newValues.erase( entry.newValues.begin(), entry.newValues.end() );
 
       entry.op = static_cast<ChangesetEntry::OperationType>( type );
       entry.table = &mCurrentTable;

--- a/geodiff/src/changesetutils.h
+++ b/geodiff/src/changesetutils.h
@@ -22,7 +22,7 @@ ChangesetTable schemaToChangesetTable( const std::string &tableName, const Table
 
 void invertChangeset( ChangesetReader &reader, ChangesetWriter &writer );
 
-void concatChangesets( std::vector<std::string> filenames, std::string outputChangeset );
+void concatChangesets( const std::vector<std::string> &filenames, const std::string &outputChangeset );
 
 std::string changesetEntryToJSON( const ChangesetEntry &entry );
 

--- a/geodiff/src/changesetutils.h
+++ b/geodiff/src/changesetutils.h
@@ -22,6 +22,8 @@ ChangesetTable schemaToChangesetTable( const std::string &tableName, const Table
 
 void invertChangeset( ChangesetReader &reader, ChangesetWriter &writer );
 
+void concatChangesets( std::vector<std::string> filenames, std::string outputChangeset );
+
 std::string changesetEntryToJSON( const ChangesetEntry &entry );
 
 std::string changesetToJSON( ChangesetReader &reader );

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -235,6 +235,21 @@ GEODIFF_EXPORT int GEODIFF_listChangesSummary(
   const char *jsonfile
 );
 
+/**
+ * Combine multiple changeset files into a single changeset file. When the output changeset
+ * is applied to a database, the result should be the same as if the input changesets were applied
+ * one by one. The order of input files is important. At least two input files need to be
+ * provided.
+ *
+ * Incompatible changes (which would cause conflicts when applied) will be discarded.
+ *
+ * \returns GEODIFF_SUCCESS on success
+ */
+GEODIFF_EXPORT int GEODIFF_concatChanges(
+  int inputChangesetsCount,
+  const char **inputChangesets,
+  const char *outputChangeset
+);
 
 /**
  * Makes a copy of the source dataset (a collection of tables) to the specified destination.

--- a/geodiff/src/geodiffrebase.cpp
+++ b/geodiff/src/geodiffrebase.cpp
@@ -27,7 +27,6 @@
 #include <fstream>
 #include <sstream>
 
-#include "sqlite3.h"  // for concatChangesets
 
 /**
  * structure that keeps track of information needed for rebase extracted
@@ -617,47 +616,3 @@ int rebase( const std::string &changeset_BASE_THEIRS,
 
   return GEODIFF_SUCCESS;
 }
-
-bool concatChangesets( const std::string &A, const std::string &B, const std::string &C, const std::string &out )
-{
-  Buffer bufA;
-  bufA.read( A );
-
-  Buffer bufB;
-  bufB.read( B );
-
-  Buffer bufC;
-  bufC.read( C );
-
-  if ( bufA.isEmpty() && bufB.isEmpty() && bufC.isEmpty() )
-  {
-    return true;
-  }
-
-  sqlite3_changegroup *pGrp;
-  int rc = sqlite3changegroup_new( &pGrp );
-  if ( rc == SQLITE_OK ) rc = sqlite3changegroup_add( pGrp, bufA.size(), bufA.v_buf() );
-  if ( rc == SQLITE_OK ) rc = sqlite3changegroup_add( pGrp, bufB.size(), bufB.v_buf() );
-  if ( rc == SQLITE_OK ) rc = sqlite3changegroup_add( pGrp, bufC.size(), bufC.v_buf() );
-  if ( rc == SQLITE_OK )
-  {
-    int pnOut = 0;
-    void *ppOut = nullptr;
-    rc = sqlite3changegroup_output( pGrp, &pnOut, &ppOut );
-    if ( rc )
-    {
-      sqlite3changegroup_delete( pGrp );
-      return true;
-    }
-
-    Buffer bufO;
-    bufO.read( pnOut, ppOut );
-    bufO.write( out );
-  }
-
-  if ( pGrp )
-    sqlite3changegroup_delete( pGrp );
-
-  return false;
-}
-

--- a/geodiff/src/geodiffrebase.hpp
+++ b/geodiff/src/geodiffrebase.hpp
@@ -17,8 +17,5 @@ int rebase(
   std::vector<ConflictFeature> &conflicts// out
 );
 
-// true on error
-bool concatChangesets( const std::string &A, const std::string &B, const std::string &C, const std::string &out );
-
 
 #endif // GEODIFFREBASE_H

--- a/geodiff/tests/geodiff_testutils.hpp
+++ b/geodiff/tests/geodiff_testutils.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "geodiff.h"
 #include "geodiff_config.hpp"
@@ -52,6 +53,20 @@ bool fileExists( const std::string &filepath );
 
 //! Tests whether a file is empty (has zero size). \note returns false when file does not exist
 bool isFileEmpty( const std::string &filepath );
+
+struct ChangesetTable;
+struct ChangesetEntry;
+
+//! Helper function to write a diff file for a couple of tables
+void writeChangeset( std::string filename, const std::unordered_map<std::string, ChangesetTable> &tables,
+                     const std::unordered_map<std::string, std::vector<ChangesetEntry> > &entries );
+
+//! Writes a diff file with a couple of entries for a single table
+void writeSingleTableChangeset( std::string filename, const ChangesetTable &table, std::vector<ChangesetEntry> entries );
+
+//! A single changeset can be stored in different ways (e.g. different order of entries)
+//! so this function tests whether they are actually the same
+bool compareDiffsByContent( std::string diffA, std::string diffB );
 
 #ifdef HAVE_POSTGRES
 /**


### PR DESCRIPTION
Also completely rewrite concatenation implementation which we used from sqlite3 "session" extension, now switched to our own implementation using changeset reader/writer abstractions.

Fixes #119 
Fixes #118