### PR TITLE
Add API to safely make a copy of a SQLite database

### DIFF
--- a/geodiff/src/drivers/sqliteutils.cpp
+++ b/geodiff/src/drivers/sqliteutils.cpp
@@ -35,6 +35,16 @@ void Sqlite3Db::open( const std::string &filename )
   }
 }
 
+void Sqlite3Db::openReadOnly( const std::string &filename )
+{
+  close();
+  int rc = sqlite3_open_v2( filename.c_str(), &mDb, SQLITE_OPEN_READONLY, nullptr );
+  if ( rc )
+  {
+    throw GeoDiffException( "Unable to open " + filename + " as sqlite3 database" );
+  }
+}
+
 void Sqlite3Db::create( const std::string &filename )
 {
   close();

--- a/geodiff/src/drivers/sqliteutils.h
+++ b/geodiff/src/drivers/sqliteutils.h
@@ -28,6 +28,7 @@ class Sqlite3Db
     Sqlite3Db();
     ~Sqlite3Db();
     void open( const std::string &filename );
+    void openReadOnly( const std::string &filename );
     //! Creates DB file (overwrites if one exists already)
     void create( const std::string &filename );
     void exec( const Buffer &buf );

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -667,14 +667,6 @@ int GEODIFF_makeCopySqlite( const char *src, const char *dst )
     return GEODIFF_ERROR;
   }
 
-  sqlite3 *pFrom;
-  int rc1 = sqlite3_open_v2( src, &pFrom, SQLITE_OPEN_READONLY, nullptr );
-  if ( rc1 != SQLITE_OK )
-  {
-    Logger::instance().error( "MakeCopySqlite: Unable to open source database: " + std::string( src ) );
-    return GEODIFF_ERROR;
-  }
-
   // If the destination file already exists, let's replace it. This is for convenience: if the file exists
   // and it is SQLite database, the backup API would overwrite it, but if the file would not be a valid
   // SQLite database, it would fail to open. With this check+remove we make sure that any existing file
@@ -684,10 +676,19 @@ int GEODIFF_makeCopySqlite( const char *src, const char *dst )
     fileremove( dst );
   }
 
+  sqlite3 *pFrom;
+  int rc1 = sqlite3_open_v2( src, &pFrom, SQLITE_OPEN_READONLY, nullptr );
+  if ( rc1 != SQLITE_OK )
+  {
+    Logger::instance().error( "MakeCopySqlite: Unable to open source database: " + std::string( src ) );
+    return GEODIFF_ERROR;
+  }
+
   sqlite3 *pTo;
   int rc2 = sqlite3_open_v2( dst, &pTo, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr );
   if ( rc2 != SQLITE_OK )
   {
+    sqlite3_close( pFrom );
     Logger::instance().error( "MakeCopySqlite: Unable to open destination database: " + std::string( dst ) );
     return GEODIFF_ERROR;
   }
@@ -715,6 +716,7 @@ int GEODIFF_makeCopySqlite( const char *src, const char *dst )
   if ( sqlite3_errcode( pTo ) )
     errorMsg = sqlite3_errmsg( pTo );
 
+  sqlite3_close( pFrom );
   sqlite3_close( pTo );
 
   if ( !errorMsg.empty() )

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -13,6 +13,8 @@
 #include "changesetutils.h"
 #include "changesetwriter.h"
 
+#include "sqliteutils.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -676,19 +678,23 @@ int GEODIFF_makeCopySqlite( const char *src, const char *dst )
     fileremove( dst );
   }
 
-  sqlite3 *pFrom;
-  int rc1 = sqlite3_open_v2( src, &pFrom, SQLITE_OPEN_READONLY, nullptr );
-  if ( rc1 != SQLITE_OK )
+  Sqlite3Db dbFrom, dbTo;
+  try
+  {
+    dbFrom.openReadOnly( src );
+  }
+  catch ( GeoDiffException e )
   {
     Logger::instance().error( "MakeCopySqlite: Unable to open source database: " + std::string( src ) );
     return GEODIFF_ERROR;
   }
 
-  sqlite3 *pTo;
-  int rc2 = sqlite3_open_v2( dst, &pTo, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr );
-  if ( rc2 != SQLITE_OK )
+  try
   {
-    sqlite3_close( pFrom );
+    dbTo.create( dst );
+  }
+  catch ( GeoDiffException e )
+  {
     Logger::instance().error( "MakeCopySqlite: Unable to open destination database: " + std::string( dst ) );
     return GEODIFF_ERROR;
   }
@@ -705,7 +711,7 @@ int GEODIFF_makeCopySqlite( const char *src, const char *dst )
   // connection pTo. If no error occurred, then the error code belonging
   // to pTo is set to SQLITE_OK.
 
-  sqlite3_backup *pBackup = sqlite3_backup_init( pTo, "main", pFrom, "main" );
+  sqlite3_backup *pBackup = sqlite3_backup_init( dbTo.get(), "main", dbFrom.get(), "main" );
   if ( pBackup )
   {
     sqlite3_backup_step( pBackup, -1 );
@@ -713,11 +719,8 @@ int GEODIFF_makeCopySqlite( const char *src, const char *dst )
   }
 
   std::string errorMsg;
-  if ( sqlite3_errcode( pTo ) )
-    errorMsg = sqlite3_errmsg( pTo );
-
-  sqlite3_close( pFrom );
-  sqlite3_close( pTo );
+  if ( sqlite3_errcode( dbTo.get() ) )
+    errorMsg = sqlite3_errmsg( dbTo.get() );
 
   if ( !errorMsg.empty() )
   {

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -272,6 +272,15 @@ GEODIFF_EXPORT int GEODIFF_makeCopy( const char *driverSrcName, const char *driv
                                      const char *driverDstName, const char *driverDstExtraInfo, const char *dst );
 
 /**
+ * Makes a copy of a SQLite database. If the destination database file exists, it will be overwritten.
+ *
+ * This is the preferred way of copying SQLite/GeoPackage files compared to just using raw copying
+ * of files on the file system: it will take into account other readers/writers and WAL file,
+ * so we should never end up with a corrupt copy.
+ */
+GEODIFF_EXPORT int GEODIFF_makeCopySqlite( const char *src, const char *dst );
+
+/**
  * This is an extended version of GEODIFF_createChangeset() which also allows specification
  * of the driver and its extra connection info. The original GEODIFF_createChangeset() function
  * only supports Sqlite driver.

--- a/geodiff/tests/CMakeLists.txt
+++ b/geodiff/tests/CMakeLists.txt
@@ -44,6 +44,8 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_BINARY_DIR}/src
   ${CMAKE_SOURCE_DIR}/src
+  ${SQLite3_INCLUDE_DIRS}   # external sqlite
+  ${sqlite3_dir}            # internal sqlite
 )
 
 ADD_LIBRARY(geodifftestutils OBJECT geodiff_testutils.hpp geodiff_testutils.cpp)


### PR DESCRIPTION
This can be used by callers when there's a need to copy SQLite files
to ensure that we do things cleanly in regard to other readers/writers
and WAL file.