### PR TITLE
API to get database schema

### DIFF
--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -695,6 +695,12 @@ int GEODIFF_dumpData( const char *driverName, const char *driverExtraInfo, const
 
 int GEODIFF_schema( const char *driverName, const char *driverExtraInfo, const char *src, const char *json )
 {
+  if ( !driverName || !src || !json )
+  {
+    Logger::instance().error( "NULL arguments to GEODIFF_schema" );
+    return GEODIFF_ERROR;
+  }
+
   std::unique_ptr<Driver> driver( Driver::createDriver( std::string( driverName ) ) );
   if ( !driver )
   {
@@ -715,7 +721,7 @@ int GEODIFF_schema( const char *driverName, const char *driverExtraInfo, const c
     std::vector<std::string> tablesData;
     for ( const std::string &tableName : driver->listTables() )
     {
-      TableSchema tbl = driver->tableSchema( tableName );
+      const TableSchema tbl = driver->tableSchema( tableName );
 
       std::vector<std::string> columnsJson;
       for ( const TableColumnInfo &column : tbl.columns )

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -693,6 +693,111 @@ int GEODIFF_dumpData( const char *driverName, const char *driverExtraInfo, const
 }
 
 
+int GEODIFF_schema( const char *driverName, const char *driverExtraInfo, const char *src, const char *json )
+{
+  std::unique_ptr<Driver> driver( Driver::createDriver( std::string( driverName ) ) );
+  if ( !driver )
+  {
+    Logger::instance().error( "Cannot create driver " + std::string( driverName ) );
+    return GEODIFF_ERROR;
+  }
+
+  try
+  {
+    // open source
+    std::map<std::string, std::string> conn;
+    conn["base"] = std::string( src );
+    if ( driverExtraInfo )
+      conn["conninfo"] = std::string( driverExtraInfo );
+    driver->open( conn );
+
+    // prepare JSON
+    std::vector<std::string> tablesData;
+    for ( const std::string &tableName : driver->listTables() )
+    {
+      TableSchema tbl = driver->tableSchema( tableName );
+
+      std::vector<std::string> columnsJson;
+      for ( const TableColumnInfo &column : tbl.columns )
+      {
+        std::vector<std::string> columnData;
+        columnData.push_back( "\"name\": \"" + jsonQuoted( column.name ) + "\"" );
+        columnData.push_back( "\"type\": \"" + TableColumnType::baseTypeToString( column.type.baseType ) + "\"" );
+        columnData.push_back( "\"type_db\": \"" + jsonQuoted( column.type.dbType ) + "\"" );
+        if ( column.isPrimaryKey )
+          columnData.push_back( "\"primary_key\": true" );
+        if ( column.isNotNull )
+          columnData.push_back( "\"not_null\": true" );
+        if ( column.isAutoIncrement )
+          columnData.push_back( "\"auto_increment\": true" );
+        if ( column.isGeometry )
+        {
+          std::vector<std::string> geometryData;
+          geometryData.push_back( "\"type\": \"" + jsonQuoted( column.geomType ) + "\"" );
+          geometryData.push_back( "\"srs_id\": \"" + std::to_string( column.geomSrsId ) + "\"" );
+          if ( column.geomHasZ )
+            geometryData.push_back( "\"has_z\": true" );
+          if ( column.geomHasM )
+            geometryData.push_back( "\"has_m\": true" );
+
+          std::string geometryJson;
+          geometryJson += "\"geometry\": {\n               ";
+          geometryJson += join( geometryData.begin(), geometryData.end(), ",\n               " );
+          geometryJson += "\n            }";
+          columnData.push_back( geometryJson );
+        }
+
+        std::string columnJson;
+        columnJson += "         {\n";
+        columnJson += "            ";
+        columnJson += join( columnData.begin(), columnData.end(), ",\n            " );
+        columnJson += "\n         }";
+
+        columnsJson.push_back( columnJson );
+      }
+
+      std::vector<std::string> tableData;
+      tableData.push_back( "\"table\": \"" + jsonQuoted( tableName ) + "\"" );
+      tableData.push_back( "\"columns\": [\n" + join( columnsJson.begin(), columnsJson.end(), ",\n" ) + "\n         ]" );
+      if ( tbl.crs.srsId != 0 )
+      {
+        std::vector<std::string> crsData;
+        crsData.push_back( "\"srs_id\": " + std::to_string( tbl.crs.srsId ) );
+        crsData.push_back( "\"auth_name\": \"" + tbl.crs.authName + "\"" );
+        crsData.push_back( "\"auth_code\": " + std::to_string( tbl.crs.authCode ) );
+        crsData.push_back( "\"wkt\": \"" + jsonQuoted( tbl.crs.wkt ) + "\"" );
+
+        std::string crsJson;
+        crsJson += "\"crs\": {\n            ";
+        crsJson += join( crsData.begin(), crsData.end(), ",\n            " );
+        crsJson += "\n         }";
+        tableData.push_back( crsJson );
+      }
+      std::string tableJson;
+      tableJson += "      {\n         ";
+      tableJson += join( tableData.begin(), tableData.end(), ",\n         " );
+      tableJson += "\n      }";
+
+      tablesData.push_back( tableJson );
+    }
+    std::string res = "{\n   \"geodiff_schema\": [\n";
+    res += join( tablesData.begin(), tablesData.end(), ",\n   " );
+    res += "\n   ]\n";
+    res += "}\n";
+
+    // write file content
+    flushString( json, res );
+  }
+  catch ( GeoDiffException exc )
+  {
+    Logger::instance().error( exc );
+    return GEODIFF_ERROR;
+  }
+
+  return GEODIFF_SUCCESS;
+}
+
+
 GEODIFF_ChangesetReaderH GEODIFF_readChangeset( const char *changeset )
 {
   if ( !changeset )

--- a/geodiff/src/geodiff.h
+++ b/geodiff/src/geodiff.h
@@ -342,6 +342,11 @@ GEODIFF_EXPORT int GEODIFF_rebaseEx(
 GEODIFF_EXPORT int GEODIFF_dumpData( const char *driverName, const char *driverExtraInfo,
                                      const char *src, const char *changeset );
 
+/**
+ * Writes a JSON file containing database schema of tables as understood by geodiff.
+ */
+GEODIFF_EXPORT int GEODIFF_schema( const char *driverName, const char *driverExtraInfo, const char *src, const char *json );
+
 
 typedef void *GEODIFF_ChangesetReaderH;
 typedef void *GEODIFF_ChangesetEntryH;

--- a/geodiff/src/geodiffutils.hpp
+++ b/geodiff/src/geodiffutils.hpp
@@ -7,6 +7,7 @@
 #define GEODIFFUTILS_H
 
 #include <string>
+#include <sstream>
 #include <memory>
 #include <exception>
 #include <vector>
@@ -97,6 +98,28 @@ std::string replace( const std::string &str, const std::string &substr, const st
 
 //! writes std::string to file
 void flushString( const std::string &filename, const std::string &str );
+
+//! Joins a container of strings together using a separator
+//! from https://codereview.stackexchange.com/questions/142902/simple-string-joiner-in-modern-c
+template<typename InputIt> std::string join( InputIt begin, InputIt end, const std::string &separator )
+{
+  std::ostringstream ss;
+  if ( begin != end )
+    ss << *begin++;
+
+  while ( begin != end )
+  {
+    ss << separator;
+    ss << *begin++;
+  }
+  return ss.str();
+}
+
+//! Quotes strings for use in JSON
+inline std::string jsonQuoted( const std::string &str )
+{
+  return replace( str, "\"", "\\\"" );
+}
 
 // SOME SQL
 

--- a/geodiff/src/tableschema.cpp
+++ b/geodiff/src/tableschema.cpp
@@ -238,3 +238,19 @@ TableColumnType columnType( const std::string &columnType, const std::string &dr
   else
     throw GeoDiffException( "Uknown driver name " + driverName );
 }
+
+std::string TableColumnType::baseTypeToString( TableColumnType::BaseType t )
+{
+  switch ( t )
+  {
+    case TEXT:     return "text";
+    case INTEGER:  return "integer";
+    case DOUBLE:   return "double";
+    case BOOLEAN:  return "boolean";
+    case BLOB:     return "blob";
+    case GEOMETRY: return "geometry";
+    case DATE:     return "date";
+    case DATETIME: return "datetime";
+  }
+  return "?";
+}

--- a/geodiff/src/tableschema.h
+++ b/geodiff/src/tableschema.h
@@ -30,6 +30,9 @@ struct TableColumnType
   BaseType baseType = TEXT;
   std::string dbType;
 
+  //! Returns string representation of the base type enum value
+  static std::string baseTypeToString( BaseType t );
+
   //! Unified conversion of GeoPackage and PostgreSQL types to base types
   void convertToBaseType();
 

--- a/geodiff/tests/test_changeset_utils.cpp
+++ b/geodiff/tests/test_changeset_utils.cpp
@@ -378,6 +378,21 @@ TEST( ChangesetUtils, test_concat_changesets_multiple_tables )
   } );
 }
 
+TEST( ChangesetUtils, test_schema )
+{
+  makedir( pathjoin( tmpdir(), "test_schema" ) );
+  std::string base = pathjoin( testdir(), "base.gpkg" );
+  std::string schema = pathjoin( tmpdir(), "test_schema", "schema.json" );
+
+  // invalid inputs
+  EXPECT_EQ( GEODIFF_schema( "qqq", nullptr, base.data(), schema.data() ), GEODIFF_ERROR );
+  EXPECT_EQ( GEODIFF_schema( "sqlite", nullptr, "--bad filename--", schema.data() ), GEODIFF_ERROR );
+
+  // valid input
+  EXPECT_EQ( GEODIFF_schema( "sqlite", nullptr, base.data(), schema.data() ), GEODIFF_SUCCESS );
+  EXPECT_TRUE( fileContentEquals( pathjoin( testdir(), "schema", "base-schema.json" ), schema ) );
+}
+
 int main( int argc, char **argv )
 {
   testing::InitGoogleTest( &argc, argv );

--- a/geodiff/tests/testdata/schema/base-schema.json
+++ b/geodiff/tests/testdata/schema/base-schema.json
@@ -1,0 +1,42 @@
+{
+   "geodiff_schema": [
+      {
+         "table": "simple",
+         "columns": [
+         {
+            "name": "fid",
+            "type": "integer",
+            "type_db": "INTEGER",
+            "primary_key": true,
+            "not_null": true,
+            "auto_increment": true
+         },
+         {
+            "name": "geometry",
+            "type": "geometry",
+            "type_db": "POINT",
+            "geometry": {
+               "type": "POINT",
+               "srs_id": "4326"
+            }
+         },
+         {
+            "name": "name",
+            "type": "text",
+            "type_db": "TEXT"
+         },
+         {
+            "name": "rating",
+            "type": "integer",
+            "type_db": "MEDIUMINT"
+         }
+         ],
+         "crs": {
+            "srs_id": 4326,
+            "auth_name": "EPSG",
+            "auth_code": 4326,
+            "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+         }
+      }
+   ]
+}


### PR DESCRIPTION
This will write database schema as a JSON file, which can be further used by clients to get more context of how geodiff understands a particular data source, because changesets (diffs) do not contain all information we may want to know when reading them (e.g. column names, types, geometry info, crs info).

Good for debugging as well...