### PR TITLE
Open source DB in read/write mode when copying database

### DIFF
--- a/geodiff/src/drivers/sqliteutils.cpp
+++ b/geodiff/src/drivers/sqliteutils.cpp
@@ -35,16 +35,6 @@ void Sqlite3Db::open( const std::string &filename )
   }
 }
 
-void Sqlite3Db::openReadOnly( const std::string &filename )
-{
-  close();
-  int rc = sqlite3_open_v2( filename.c_str(), &mDb, SQLITE_OPEN_READONLY, nullptr );
-  if ( rc )
-  {
-    throw GeoDiffException( "Unable to open " + filename + " as sqlite3 database" );
-  }
-}
-
 void Sqlite3Db::create( const std::string &filename )
 {
   close();

--- a/geodiff/src/drivers/sqliteutils.h
+++ b/geodiff/src/drivers/sqliteutils.h
@@ -28,7 +28,6 @@ class Sqlite3Db
     Sqlite3Db();
     ~Sqlite3Db();
     void open( const std::string &filename );
-    void openReadOnly( const std::string &filename );
     //! Creates DB file (overwrites if one exists already)
     void create( const std::string &filename );
     void exec( const Buffer &buf );

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -694,7 +694,7 @@ int GEODIFF_makeCopySqlite( const char *src, const char *dst )
   Sqlite3Db dbFrom, dbTo;
   try
   {
-    dbFrom.openReadOnly( src );
+    dbFrom.open( src );
   }
   catch ( GeoDiffException e )
   {


### PR DESCRIPTION
Fixes #132

Even though it is possible to open databases in WAL mode as read-only since sqlite 3.22 (released in 2018), there seem to be a couple of limitations: https://sqlite.org/wal.html#readonly

The -wal and -shm are left behind even after the database is closed. So better let's open it in read/write mode as usual and those files will get proper treatment - they will be removed when connection is closed.