### PR TITLE
fix diff between two postgresql databases (fix #185)

### DIFF
--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -29,6 +29,12 @@ jobs:
           sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION postgis;"'
           sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION \"uuid-ossp\";"'
           sudo runuser -l postgres -c 'psql -c "GRANT ALL PRIVILEGES ON DATABASE geodiffdb TO geodiffuser"'
+          # second database, to test diffs between different databases and same schemas,
+          # see https://github.com/MerginMaps/geodiff/issues/185
+          sudo runuser -l postgres -c 'psql -c "CREATE DATABASE geodiffdb2"'
+          sudo runuser -l postgres -c 'psql -d "geodiffdb2" -c "CREATE EXTENSION postgis;"'
+          sudo runuser -l postgres -c 'psql -d "geodiffdb2" -c "CREATE EXTENSION \"uuid-ossp\";"'
+          sudo runuser -l postgres -c 'psql -c "GRANT ALL PRIVILEGES ON DATABASE geodiffdb2 TO geodiffuser"'
 
       - name: build geodiff with coverage
         run: |
@@ -46,6 +52,7 @@ jobs:
         env:
           CTEST_TARGET_SYSTEM: Linux-gcc
           GEODIFF_PG_CONNINFO: "host=localhost port=5432 user=geodiffuser password=geodiffpass dbname=geodiffdb"
+          GEODIFF_PG_CONNINFO2: "host=localhost port=5432 user=geodiffuser password=geodiffpass dbname=geodiffdb2"
         run: |
           cd build_coverage_lnx
           ctest -VV

--- a/.github/workflows/memcheck_tests.yml
+++ b/.github/workflows/memcheck_tests.yml
@@ -29,7 +29,12 @@ jobs:
           sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION postgis;"'
           sudo runuser -l postgres -c 'psql -d "geodiffdb" -c "CREATE EXTENSION \"uuid-ossp\";"'
           sudo runuser -l postgres -c 'psql -c "GRANT ALL PRIVILEGES ON DATABASE geodiffdb TO geodiffuser"'
-
+          # second database, to test diffs between different databases and same schemas,
+          # see https://github.com/MerginMaps/geodiff/issues/185
+          sudo runuser -l postgres -c 'psql -c "CREATE DATABASE geodiffdb2"'
+          sudo runuser -l postgres -c 'psql -d "geodiffdb2" -c "CREATE EXTENSION postgis;"'
+          sudo runuser -l postgres -c 'psql -d "geodiffdb2" -c "CREATE EXTENSION \"uuid-ossp\";"'
+          sudo runuser -l postgres -c 'psql -c "GRANT ALL PRIVILEGES ON DATABASE geodiffdb2 TO geodiffuser"'
 
       - name: build geodiff with valgrind
         run: |
@@ -50,6 +55,7 @@ jobs:
           GLIBCPP_FORCE_NEW: 1
           GLIBCXX_FORCE_NEW: 1
           GEODIFF_PG_CONNINFO: "host=localhost port=5432 user=geodiffuser password=geodiffpass dbname=geodiffdb"
+          GEODIFF_PG_CONNINFO2: "host=localhost port=5432 user=geodiffuser password=geodiffpass dbname=geodiffdb2"
         run: |
           cd build_memcheck_lnx
           ctest -T memcheck 2>&1 | tee memcheck.log

--- a/geodiff/src/geodiff.cpp
+++ b/geodiff/src/geodiff.cpp
@@ -221,7 +221,9 @@ int GEODIFF_createChangesetDr( GEODIFF_ContextH contextHandle, const char *drive
     return GEODIFF_ERROR;
   }
 
-  if ( strcmp( driverSrcName, driverDstName ) == 0 )
+  // check both driver names and connection details, for more context
+  // see https://github.com/MerginMaps/geodiff/issues/185
+  if ( strcmp( driverSrcName, driverDstName ) == 0 && strcmp( driverSrcExtraInfo, driverDstExtraInfo ) == 0 )
   {
     return GEODIFF_createChangesetEx( contextHandle, driverSrcName, driverSrcExtraInfo, src, dst, changeset );
   }

--- a/geodiff/tests/geodiff_testutils.cpp
+++ b/geodiff/tests/geodiff_testutils.cpp
@@ -364,8 +364,13 @@ bool compareDiffsByContent( std::string diffA, std::string diffB )
 }
 
 #ifdef HAVE_POSTGRES
-std::string pgTestConnInfo()
+std::string pgTestConnInfo( bool secondInstance )
 {
+  if ( secondInstance )
+  {
+    return getEnvVar( "GEODIFF_PG_CONNINFO2", "" );
+  }
+
   return getEnvVar( "GEODIFF_PG_CONNINFO", "" );
 }
 #endif

--- a/geodiff/tests/geodiff_testutils.hpp
+++ b/geodiff/tests/geodiff_testutils.hpp
@@ -67,11 +67,14 @@ bool compareDiffsByContent( std::string diffA, std::string diffB );
 
 #ifdef HAVE_POSTGRES
 /**
- * Returns the connection info for the postgres database
- * Use GEODIFF_PG_CONNINFO env variable for setup
+ * Returns the connection info for the postgres databases
+ * Use GEODIFF_PG_CONNINFO and GEODIFF_PG_CONNINFO2 env variables for setup.
+ * By default returns connection info defined by GEODIFF_PG_CONNINFO, to
+ * access connection info from GEODIFF_PG_CONNINFO2 env variable set
+ * secondInstance to true.
  * Returns empty string by default
  */
-std::string pgTestConnInfo();
+std::string pgTestConnInfo( bool secondInstance = false );
 #endif
 
 #endif // GEODIFF_TESTUTILS_HPP

--- a/geodiff/tests/testdata/postgres/diff.sql
+++ b/geodiff/tests/testdata/postgres/diff.sql
@@ -1,0 +1,19 @@
+DROP SCHEMA IF EXISTS gd_pg_diff CASCADE;
+CREATE SCHEMA gd_pg_diff;
+
+CREATE TABLE gd_pg_diff.simple (
+    "fid" SERIAL PRIMARY KEY,
+    "geometry" GEOMETRY(POINT, 4326),
+    "name" text
+);
+
+INSERT INTO gd_pg_diff.simple (
+    "fid",
+    "geometry",
+    "name"
+)
+VALUES (
+    1,
+    ST_GeomFromText('Point (0 1)', 4326),
+    'feature 1'
+);

--- a/geodiff/tests/testdata/postgres/diff2.sql
+++ b/geodiff/tests/testdata/postgres/diff2.sql
@@ -1,0 +1,30 @@
+DROP SCHEMA IF EXISTS gd_pg_diff CASCADE;
+CREATE SCHEMA gd_pg_diff;
+
+CREATE TABLE gd_pg_diff.simple (
+    "fid" SERIAL PRIMARY KEY,
+    "geometry" GEOMETRY(POINT, 4326),
+    "name" text
+);
+
+INSERT INTO gd_pg_diff.simple (
+    "fid",
+    "geometry",
+    "name"
+)
+VALUES (
+    1,
+    ST_GeomFromText('Point (0 1)', 4326),
+    'feature 1'
+);
+
+INSERT INTO gd_pg_diff.simple (
+    "fid",
+    "geometry",
+    "name"
+)
+VALUES (
+    2,
+    ST_GeomFromText('Point (1 2)', 4326),
+    'feature 2'
+);


### PR DESCRIPTION
Check not only driver name, but also connection details when creating changeset between two PostgreSQL databases.

Fixes #185.