### PR TITLE
Fix updating rows with microsecond timestamps in Postgres

### DIFF
--- a/geodiff/src/drivers/postgresdriver.cpp
+++ b/geodiff/src/drivers/postgresdriver.cpp
@@ -393,8 +393,9 @@ static std::string allColumnNames( const TableSchema &tbl, const std::string &pr
     else if ( c.type == "timestamp without time zone" )
     {
       // by default postgresql would return date/time as a formatted string
-      // e.g. "2020-07-13 16:17:54" but we want IS0-8601 format "2020-07-13T16:17:54.60Z"
-      columns += "to_char(" + name + ",'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"')";
+      // e.g. "2020-07-13 16:17:54" but we want IS0-8601 format "2020-07-13T16:17:54.060110Z"
+      // Our format needs to capture the full resolution of Postgres timestamps (microseconds)
+      columns += "to_char(" + name + ",'YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')";
     }
     else
       columns += name;

--- a/geodiff/tests/test_driver_postgres.cpp
+++ b/geodiff/tests/test_driver_postgres.cpp
@@ -1090,6 +1090,9 @@ TEST( PostgresDriverTest, test_timestamp_miliseconds )
   EXPECT_EQ( resTimeStamp2.value( 0, 0 ), "2021-10-28 18:34:19" );
   PostgresResult resTimeStamp3( execSql( c, "select created from gd_tz_base.simple where fid = 3" ) );
   EXPECT_EQ( resTimeStamp3.value( 0, 0 ), "2021-10-28 18:34:19.53" );
+  // Check that rows with microsecond-precision timestamps get updated properly
+  PostgresResult resNote4( execSql( c, "select note from gd_tz_base.simple where fid = 4" ) );
+  EXPECT_EQ( resNote4.value( 0, 0 ), "row 4 updated" );
 
   PQfinish( c );
 }

--- a/geodiff/tests/testdata/postgres/tz_miliseconds.sql
+++ b/geodiff/tests/testdata/postgres/tz_miliseconds.sql
@@ -3,8 +3,9 @@ DROP SCHEMA IF EXISTS gd_tz_base CASCADE;
 
 CREATE SCHEMA gd_tz_base;
 
-CREATE TABLE gd_tz_base.simple ( "fid" SERIAL PRIMARY KEY, "geometry" GEOMETRY(POINT, 4326), "created" TIMESTAMP WITHOUT TIME ZONE);
+CREATE TABLE gd_tz_base.simple ( "fid" SERIAL PRIMARY KEY, note TEXT, "created" TIMESTAMP WITHOUT TIME ZONE);
 
-INSERT INTO gd_tz_base.simple VALUES (1, ST_GeomFromText('Point (-1.08891928864569065 0.46101231190150482)', 4326), '2021-10-28 18:34:19.474');
-INSERT INTO gd_tz_base.simple VALUES (2, ST_GeomFromText('Point (-0.36388508891928861 0.56224350205198359)', 4326), '2021-10-28 18:34:19.476');
-INSERT INTO gd_tz_base.simple VALUES (3, ST_GeomFromText('Point (-0.73050615595075241 0.04240766073871405)', 4326));
+INSERT INTO gd_tz_base.simple VALUES (1, 'row 1', '2021-10-28 18:34:19.474');
+INSERT INTO gd_tz_base.simple VALUES (2, 'row 2', '2021-10-28 18:34:19.476');
+INSERT INTO gd_tz_base.simple VALUES (3, 'row 3');
+INSERT INTO gd_tz_base.simple VALUES (4, 'row 4', '2025-12-03 17:21:23.130895');

--- a/geodiff/tests/testdata/postgres/tz_updated.sql
+++ b/geodiff/tests/testdata/postgres/tz_updated.sql
@@ -3,8 +3,9 @@ DROP SCHEMA IF EXISTS gd_tz_updated CASCADE;
 
 CREATE SCHEMA gd_tz_updated;
 
-CREATE TABLE gd_tz_updated.simple ( "fid" SERIAL PRIMARY KEY, "geometry" GEOMETRY(POINT, 4326), "created" TIMESTAMP WITHOUT TIME ZONE);
+CREATE TABLE gd_tz_updated.simple ( "fid" SERIAL PRIMARY KEY, note TEXT, "created" TIMESTAMP WITHOUT TIME ZONE);
 
-INSERT INTO gd_tz_updated.simple VALUES (1, ST_GeomFromText('Point (-1.08891928864569065 0.46101231190150482)', 4326), '2021-10-28 18:34:19.472');
-INSERT INTO gd_tz_updated.simple VALUES (2, ST_GeomFromText('Point (-0.36388508891928861 0.56224350205198359)', 4326), '2021-10-28 18:34:19');
-INSERT INTO gd_tz_updated.simple VALUES (3, ST_GeomFromText('Point (-0.73050615595075241 0.04240766073871405)', 4326), '2021-10-28 18:34:19.53');
+INSERT INTO gd_tz_updated.simple VALUES (1, 'row 1', '2021-10-28 18:34:19.472');
+INSERT INTO gd_tz_updated.simple VALUES (2, 'row 2', '2021-10-28 18:34:19');
+INSERT INTO gd_tz_updated.simple VALUES (3, 'row 3', '2021-10-28 18:34:19.53');
+INSERT INTO gd_tz_updated.simple VALUES (4, 'row 4 updated', '2025-12-03 17:21:23.130895');


### PR DESCRIPTION
This PR fixes the Postgres driver to read all the data in a timestamp (up to 6 decimal places), fixing issues with unapplied updates due to the truncated timestamp not matching the real data (see https://github.com/MerginMaps/db-sync/issues/145).

I updated an existing Pg timestamp test to also check for this now-solved issue.