### PR TITLE
Record edit conflict when UPDATE is rebased on top of DELETE

### DIFF
--- a/geodiff/src/geodiffrebase.cpp
+++ b/geodiff/src/geodiffrebase.cpp
@@ -471,7 +471,20 @@ bool _handle_update( const ChangesetEntry &entry, const RebaseMapping &mapping,
   {
     int newPk = mapping.getNewPkey( entry.table->name, pk );
     if ( newPk == RebaseMapping::INVALID_FID )
+    {
+      // our UPDATE conflicts with their DELETE: record as conflict, delete wins
+      ConflictFeature conflictFeature( pk, entry.table->name );
+      for ( size_t i = 0; i < numColumns; i++ )
+      {
+        if ( entry.newValues[i].type() != Value::TypeUndefined )
+        {
+          _addConflictItem( conflictFeature, ( int ) i, entry.oldValues[i], Value(), entry.newValues[i] );
+        }
+      }
+      if ( conflictFeature.isValid() )
+        conflicts.push_back( conflictFeature );
       return false;
+    }
   }
 
   // find the previously new values (will be used as the old values in the rebased version)

--- a/geodiff/tests/test_concurrent_commits.cpp
+++ b/geodiff/tests/test_concurrent_commits.cpp
@@ -381,7 +381,7 @@ TEST( ConcurrentCommitsSqlite3Test, test_delete_update )
 {
   std::cout << "geopackage concurent DELETE (base) -> (A) and UPDATE (base) -> (B)" << std::endl;
   std::cout << "(A) deleted the feature 2 and (B) edits the geom of feature 2" << std::endl;
-  std::cout << "expected result: feature 2 is deleted" << std::endl;
+  std::cout << "expected result: feature 2 is deleted, conflict recorded for the discarded update" << std::endl;
 
   bool ret = _test(
                "base.gpkg",
@@ -392,7 +392,7 @@ TEST( ConcurrentCommitsSqlite3Test, test_delete_update )
                1,
                0,
                1,
-               0
+               1
              );
   ASSERT_TRUE( ret );
 }


### PR DESCRIPTION
When rebasing a changeset where our side updates a row that the other side has deleted, the delete wins and the update is discarded. Previously this was done silently with no record in the conflict file.

This change records the discarded update as a conflict entry, so callers can inspect what data was lost. Each column that our update was changing gets a conflict item with the original (base) value and our intended new value. The `old` key is absent since the other side deleted the row rather than setting new column values.

Fixes #248