### PR TITLE
Wait for transient DB lock

### DIFF
--- a/geodiff/src/drivers/sqliteutils.cpp
+++ b/geodiff/src/drivers/sqliteutils.cpp
@@ -34,6 +34,7 @@ void Sqlite3Db::open( const std::string &filename )
   {
     throwSqliteError( mDb, "Unable to open " + filename + " as sqlite3 database" );
   }
+  sqlite3_busy_timeout( mDb, GEODIFF_SQLITE_BUSY_TIMEOUT_MS );
 }
 
 void Sqlite3Db::create( const std::string &filename )
@@ -50,6 +51,7 @@ void Sqlite3Db::create( const std::string &filename )
   {
     throwSqliteError( mDb, "Unable to create " + filename + " as sqlite3 database" );
   }
+  sqlite3_busy_timeout( mDb, GEODIFF_SQLITE_BUSY_TIMEOUT_MS );
 }
 
 void Sqlite3Db::exec( const Buffer &buf )

--- a/geodiff/src/drivers/sqliteutils.h
+++ b/geodiff/src/drivers/sqliteutils.h
@@ -18,6 +18,7 @@
 #define GPKG_NO_ENVELOPE_HEADER_SIZE 8
 #define GPKG_FLAG_BYTE_POS 3
 #define GPKG_ENVELOPE_SIZE_MASK 14
+#define GEODIFF_SQLITE_BUSY_TIMEOUT_MS 3000
 
 class Buffer;
 class Context;


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/geodiff/issues/256

This adds sqlite3_busy_timeout after opening a connection, so a transient lock is waited out rather than aborting. 
https://sqlite.org/c3ref/busy_timeout.html